### PR TITLE
Rename tool and pack to dotnet-xcsync

### DIFF
--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -17,22 +17,24 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
-  <PropertyGroup Label="nuget pkg">
+  <PropertyGroup Label="Nuget Package">
+    <IsPackable>true</IsPackable>
+    <PackageId>dotnet-xcsync</PackageId>
     <Title>xcsync</Title>
-    <PackageId>xcsync</PackageId>
+    <Description>xcsync is a .NET tool providing editing and connecting resource capabilities by using Xcode.</Description>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Company>Microsoft</Company>
     <Copyright>Microsoft Corporation</Copyright>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <IsPackable>true</IsPackable>
-    <PackageId>Microsoft.Tools.Xcsync</PackageId>
-    <EnablePackageValidation>true</EnablePackageValidation>
     <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnablePackageValidation>true</EnablePackageValidation>
+  </PropertyGroup>
+
+  <PropertyGroup Label=".Net Tool">
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>xcsync</ToolCommandName>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <Description>xcsync is a .NET tool providing editing and connecting resource capabilities by using Xcode.</Description>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change aligns the name of the tool with other .NET Tools, e.g dotnet-format

Sample Usage:
```
% dotnet tool install dotnet-xcsync
You can invoke the tool from this directory using the following commands: 'dotnet tool run xcsync' or 'dotnet xcsync'.

% dotnet xcsync
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.

Required command was not provided.

Description:
  xcsync

Usage:
  xcsync [command] [options]

Options:
  -v, --verbosity <Detailed|Diagnostic|Minimal|Normal|Quiet>  Set the verbosity level [default: Normal]
  -d, --dotnet-path <dotnet-path>                             Set the path to the .NET SDK, when not provided will use the path from the parent process if it is 'dotnet' otherwise falls back to the 'dotnet' on the PATH. []
  --version                                                   Show version information
  -?, -h, --help                                              Show help and usage information

Commands:
  generate  generate a Xcode project at the path specified by --target from the project identified by --project
  sync      synchronize changes from the Xcode project back to the.NET project
  watch     generates a Xcode project, then continuously synchronizes changes between the Xcode project and the .NET project
```