### PR TITLE
Disable IsXcodeProjectOpen test

### DIFF
--- a/test/xcsync.tests/Projects/XcodeProjectTest.cs
+++ b/test/xcsync.tests/Projects/XcodeProjectTest.cs
@@ -368,9 +368,9 @@ public class XcodeProjectTest (ITestOutputHelper TestOutput) : Base {
 		});
 	}
 
-	[Fact()]
+	[Fact (Skip="Only works interactively")]
 	[Trait ("Category", "XcodeIntegration")]
-	[SkipOnCI("Only works interactively")]
+	[SkipOnCI ("Only works interactively")]
 	public async void IsXcodeProjectOpen ()
 	{
 		// Assert to make sure Xcode successfully opens project when --open flag used


### PR DESCRIPTION
The SkipOnCI worked in the PR build but is now continuing to be ignored and the test fails, so disabling this test for the time being