### PR TITLE
Remove watch command from the help menu

### DIFF
--- a/src/xcsync/Commands/XcSyncCommand.cs
+++ b/src/xcsync/Commands/XcSyncCommand.cs
@@ -46,6 +46,7 @@ class XcSyncCommand : RootCommand {
 
 		AddCommand (new GenerateCommand (fileSystem, Logger));
 		AddCommand (new SyncCommand (fileSystem, Logger));
-		// AddCommand (new WatchCommand (fileSystem, Logger));
+		if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("EnableXcsyncWatch")))
+			AddCommand (new WatchCommand (fileSystem, Logger));
 	}
 }


### PR DESCRIPTION
The watch command is still under development so don't show this as an option yet for the tool's help menu
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/56)