### PR TITLE
Ignore dev kit extension generated sln file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -402,4 +402,4 @@ FodyWeavers.xsd
 .dotnet
 *.log
 */TestResults/
-xcsync/xcsync.sln
+src/xcsync/xcsync.sln


### PR DESCRIPTION
ignore xcsync sln created by dev kit ext, path changed after repo move
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/60)