### PR TITLE
Switch lcl files to package

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -122,9 +122,9 @@ extends:
       - ${{ if and( notin( variables['Build.Reason'], 'PullRequest' ), eq( variables['Build.SourceBranch'], 'refs/heads/main' ) ) }}:
         - template: /eng/common/templates-official/job/onelocbuild.yml@self
           parameters:
-            # LclSource: lclFilesfromPackage
-            # LclPackageId: 'LCL-JUNO-PROD-XCSYNC'
-            LclSource: lclFilesInRepo
+            LclSource: lclFilesfromPackage
+            LclPackageId: 'LCL-JUNO-PROD-XMACCORE'
+            #LclSource: lclFilesInRepo
             SkipLocProjectJsonGeneration: true
             MirrorRepo: xcsync
             MirrorBranch: main


### PR DESCRIPTION
Based on comments from https://dev.azure.com/ceapex/CEINTL/_workitems/edit/994087?src=WorkItemMention&src-action=artifact_link switching the OneLocBuild task to use a NuGet package and update the name.

Validation PR: https://dev.azure.com/dnceng/internal/_git/dotnet-xcsync/pullrequest/42719

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/67)
