### PR TITLE
be more strict for xcode monitoring filter

### DIFF
--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -42,6 +42,8 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 	Regex? fileFilterRegex;
 
+	Regex? exclusionRegex;
+
 	/// <summary>
 	/// Starts monitoring the project file changes.
 	/// </summary>
@@ -56,7 +58,7 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 		watcher.Path = fileSystem.Path.GetDirectoryName (project.RootPath)!;
 
 		watcher.NotifyFilter = NotifyFilters.CreationTime | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName;
-		watcher.Filter = "*.*";
+		watcher.Filter = "*.*"; //this isn't really used since overridden by fileFilterRegex
 		watcher.IncludeSubdirectories = true;
 
 		watcher.Changed += OnChangedHandler;
@@ -66,6 +68,9 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 		watcher.Error += OnErrorHandler;
 
 		watcher.EnableRaisingEvents = true;
+
+		var exclusionPattern = @".*\.xcodeproj/project\.xcworkspace/*"; // or:  @".*\.xcodeproj/project\.xcworkspace/(xcshareddata|xcuserdata).*";
+		exclusionRegex = new Regex (exclusionPattern, RegexOptions.IgnoreCase);
 
 		var filters = string.Join ("|", this.project.ProjectFilesFilter.Select (f => f.Replace (".", @"\.").Replace ("*", ".*").Replace ("?", ".?")));
 		if (string.IsNullOrEmpty (filters))
@@ -134,6 +139,8 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 			return;
 		}
 
+		if (exclusionRegex?.IsMatch (e.FullPath) ?? false)
+			return;
 		if (!fileFilterRegex?.IsMatch (e.FullPath) ?? false)
 			return;
 

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -23,7 +23,7 @@ using static ClangSharp.Interop.CXTranslationUnit_Flags;
 namespace xcsync.Projects;
 
 partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework) :
-	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, ["*.xcodeproj", "*.xcworkspace", "*.m", "*.h", "*.storyboard"]) {
+	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, ["*.xcodeproj", "*.m", "*.h", "*.storyboard"]) {
 
 	static CXIndex cxIndex = CXIndex.Create ();
 


### PR DESCRIPTION
addresses: 
![Screenshot 2024-09-27 at 2 34 08 PM](https://github.com/user-attachments/assets/3fa70b21-bc3c-465e-95a8-ed2575e53716)


xcshareddata and xcuserdata are usually auto-modified for Xcode so not sure if we really need to be tracking that back to .NET

read more: https://christiantietze.de/posts/2023/12/ignore-generated-xcode-xcworkspace-files-in-git-except-package-resolved/