### PR TITLE
Disable CodeQL on Arm64

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -171,7 +171,13 @@ extends:
               fetchDepth: 1
               clean: true
 
-            steps:                
+            steps: 
+
+              - pwsh: |
+                  Write-Host "##vso[task.setvariable variable=DYLD_INSERT_LIBRARIES]"
+                displayName: 'Disable CodeQL'
+                name: disableCodeQLOnArm64
+
               - template: /eng/pipelines/templates/buildandtest.yml
                 parameters:
                   dotnetScript: $(Build.SourcesDirectory)/dotnet.sh


### PR DESCRIPTION
Temporarily disable CodeQL injection on ARM64.
macOS ARM64 is still in beta: https://codeql.github.com/docs/codeql-overview/system-requirements/
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/95)