### PR TITLE
Improve exception logging

### DIFF
--- a/src/xcsync/Workers/ChangeWorker.cs
+++ b/src/xcsync/Workers/ChangeWorker.cs
@@ -29,7 +29,7 @@ class ChangeWorker (IFileSystem FileSystem, ITypeService TypeService, string Pro
 
 	public override Task ConsumeAsync (ChangeMessage message, Exception exception, CancellationToken token = default)
 	{
-		Logger.Error (exception, Strings.Watch.WorkerException (message.Id, exception.Message));
+		Logger.Error (exception, Strings.Watch.WorkerException (message.Id, exception.ToString ()));
 		//TODO: https://github.com/dotnet/xcsync/issues/82
 		return Task.CompletedTask;
 	}


### PR DESCRIPTION
Ensure exception is logged with specific details, hard to debug from just `System.String[]`