### PR TITLE
fix pbx json convert when syncing from xcode

### DIFF
--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -460,7 +460,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 
 		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework);
 
-		Scripts.ConvertPbxProjToJson (FileSystem, FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproject", "project.pbxproj"));
+		Scripts.ConvertPbxProjToJson (FileSystem, FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj", "project.pbxproj"));
 
 		await xcodeWorkspace.LoadAsync (token).ConfigureAwait (false);
 


### PR DESCRIPTION
addresses:

> [22:40:16 ERR xcsync (18)] Error processing change message c44d7217-b1c8-46c3-9bf5-d88a59b33799: System.InvalidOperationException: 'plutil System.String[]' execution failed with exit code: 1
>    at xcsync.Scripts.ExecuteCommand(String command, String[] args, TimeSpan timeout) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/Scripts.cs:line 26
>    at xcsync.Scripts.ConvertPbxProjToJson(IFileSystem fileSystem, String projectPath) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/Scripts.cs:line 34
>    at xcsync.SyncContext.SyncFromXcodeAsync(CancellationToken token) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/SyncContext.cs:line 463
>    at xcsync.SyncContext.SyncAsync(CancellationToken token) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/SyncContext.cs:line 32
>    at xcsync.ChangeWorker.ConsumeAsync(ChangeMessage message, CancellationToken cancellationToken) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/Workers/ChangeWorker.cs:line 24
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/98)


https://x.com/JPoliachik/status/1816858223577534649