### PR TITLE
fix msbuild duplicate output entries

### DIFF
--- a/src/xcsync/Scripts.cs
+++ b/src/xcsync/Scripts.cs
@@ -125,6 +125,7 @@ static class Scripts {
 		return jsonObject.SelectTokens ("$..['Compile','None'][*].FullPath")
 		   .Select (token => token.ToString ())
 		   .Where (path => !path.Contains ("Platforms") || path.Contains ($"Platforms/{targetPlatform}", StringComparison.OrdinalIgnoreCase))
+		   .Distinct ()
 		   .ToList ();
 	}
 


### PR DESCRIPTION
ref: https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/getx-duplicate-output

not that we are using that version of dotnet, but the issue persists.

verified by repro-ing the issue in an isolated instance by just running `dotnet msbuild Repro.csproj -getItem:Compile,None`

before:
![Screenshot 2024-10-03 at 5 18 52 PM](https://github.com/user-attachments/assets/a949a5e6-ccd0-43b9-8ef3-949a7fe5294c)

after:
![Screenshot 2024-10-03 at 5 20 32 PM](https://github.com/user-attachments/assets/8e24d88a-d1e9-41e9-85b9-6b494fc1fbd7)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/107)