### PR TITLE
Write file content only after all types have been updated

### DIFF
--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -497,7 +497,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 			TaskCompletionSource? tcs = null;
 			await (syncItem switch {
 #pragma warning disable CA2012 // Use ValueTasks correctly
-				SyncableType type => Hub.PublishAsync (SyncChannel, new LoadTypesFromObjCMessage (Guid.NewGuid ().ToString (), tcs = new TaskCompletionSource(), xcodeWorkspace, syncItem)),
+				SyncableType type => Hub.PublishAsync (SyncChannel, new LoadTypesFromObjCMessage (Guid.NewGuid ().ToString (), tcs = new TaskCompletionSource (), xcodeWorkspace, syncItem)),
 				SyncableContent file => Hub.PublishAsync (FileChannel, new CopyFileMessage (Guid.NewGuid ().ToString (), file.SourcePath, FileSystem.Path.Combine (basePath, file.DestinationPath))),
 				_ => ValueTask.CompletedTask
 #pragma warning restore CA2012 // Use ValueTasks correctly

--- a/src/xcsync/Workers/ObjCTypeLoader.cs
+++ b/src/xcsync/Workers/ObjCTypeLoader.cs
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Marille;
 using Serilog;
 using xcsync.Projects;
 
 namespace xcsync.Workers;
 
-readonly record struct LoadTypesFromObjCMessage (string Id, XcodeWorkspace XcodeWorkspace, ISyncableItem Item);
+readonly record struct LoadTypesFromObjCMessage (string Id, TaskCompletionSource CompletionSource, XcodeWorkspace XcodeWorkspace, ISyncableItem Item);
 
 class ObjCTypesLoader (ILogger Logger) : BaseWorker<LoadTypesFromObjCMessage> {
 	public override async Task ConsumeAsync (LoadTypesFromObjCMessage message, CancellationToken token = default)
@@ -15,6 +14,7 @@ class ObjCTypesLoader (ILogger Logger) : BaseWorker<LoadTypesFromObjCMessage> {
 		var visitor = new ObjCImplementationDeclVisitor (Logger);
 		visitor.ObjCTypes.CollectionChanged += message.XcodeWorkspace.ProcessObjCTypes;
 		await message.XcodeWorkspace.LoadTypesFromObjCFileAsync (((SyncableType) message.Item).FilePath, visitor, token);
+		message.CompletionSource.SetResult ();
 		visitor.ObjCTypes.CollectionChanged -= message.XcodeWorkspace.ProcessObjCTypes;
 	}
 

--- a/test/xcsync.tests/Projects/XcodeWorkspaceTests.cs
+++ b/test/xcsync.tests/Projects/XcodeWorkspaceTests.cs
@@ -119,13 +119,13 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 				SyncableType type => loader.ConsumeAsync (new LoadTypesFromObjCMessage (Guid.NewGuid ().ToString (), completionSource = new (), xcodeWorkspace, syncItem), CancellationToken.None),
 				_ => Task.CompletedTask
 			};
-			if ( completionSource is not null )
+			if (completionSource is not null)
 				tasks.Add (completionSource.Task);
 			tasks.Add (task);
 			await task;
 		}
 		Task.WaitAll ([.. tasks]);
-		
+
 		// Assert
 		var typeSymbol = typeService.QueryTypes (null, "ViewController").First ()?.TypeSymbol!;
 		SyntaxTree? syntaxTree = null;


### PR DESCRIPTION
This fixes a race condition where the types were being written out to disk before the types were actually updated.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/112)