### PR TITLE
Refactor Scripts to remove IFileSystem when appropriate.

### DIFF
--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -225,7 +225,7 @@ class BaseCommand<T> : Command {
 
 		tfms = [];
 		try {
-			tfms = Scripts.GetTargetFrameworksFromProject (fileSystem, csproj);
+			tfms = Scripts.GetTargetFrameworksFromProject (csproj);
 
 			return tfms.Count > 0;
 		} catch (Exception ex) {

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -140,7 +140,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		Logger?.Debug (Strings.Generate.GeneratedFiles);
 
 		// leverage msbuild to get the list of files in the project
-		var filePaths = Scripts.GetFiles (FileSystem, ProjectPath, Framework.Platform, targetPlatform);
+		var filePaths = Scripts.GetFileItemsFromProject (ProjectPath, Framework.Platform, targetPlatform);
 
 		// copy storyboard, entitlements/info.plist files to the target directory 
 		var appleFiles = filePaths.Where (path =>
@@ -218,7 +218,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		// maui support
-		foreach (var asset in Scripts.GetAssets (FileSystem, ProjectPath, Framework.ToString ())) {
+		foreach (var asset in Scripts.GetAssetItemsFromProject (ProjectPath, Framework.ToString ())) {
 			Scripts.CopyDirectory (FileSystem, asset, FileSystem.Path.Combine (TargetDir, "Assets.xcassets"), true);
 			AddAsset (asset);
 		}
@@ -262,7 +262,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		};
 		xcodeObjects.Add (pbxFrameworksBuildPhase.Token, pbxFrameworksBuildPhase);
 
-		var supportedOSVersion = Scripts.GetSupportedOSVersion (FileSystem, ProjectPath, Framework.ToString ());
+		var supportedOSVersion = Scripts.GetSupportedOSVersionForTfmFromProject (ProjectPath, Framework.ToString ());
 
 		var debugBuildConfiguration = new XCBuildConfiguration {
 			Isa = nameof (XCBuildConfiguration),
@@ -474,7 +474,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 
 		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
 
-		Scripts.ConvertPbxProjToJson (FileSystem, FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj", "project.pbxproj"));
+		Scripts.ConvertPbxProjToJson (FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj", "project.pbxproj"));
 
 		await xcodeWorkspace.LoadAsync (token).ConfigureAwait (false);
 

--- a/test/xcsync.tests/ScriptTests.cs
+++ b/test/xcsync.tests/ScriptTests.cs
@@ -85,7 +85,7 @@ public class ScriptsTests (ITestOutputHelper TestOutput) : Base {
 		var expected = frameworks.Split (';');
 
 		// Act
-		var projectFrameworks = Scripts.GetTargetFrameworksFromProject (new FileSystem (), csproj);
+		var projectFrameworks = Scripts.GetTargetFrameworksFromProject (csproj);
 
 		// Assert
 		Assert.Equal (expected, projectFrameworks);
@@ -105,7 +105,7 @@ public class ScriptsTests (ITestOutputHelper TestOutput) : Base {
 		SetTargetFrameworks (csproj, []);
 
 		// Act
-		var frameworks = Scripts.GetTargetFrameworksFromProject (new FileSystem (), csproj);
+		var frameworks = Scripts.GetTargetFrameworksFromProject (csproj);
 
 		// Assert
 		Assert.NotNull (frameworks);
@@ -136,6 +136,6 @@ public class ScriptsTests (ITestOutputHelper TestOutput) : Base {
 		var csproj = Path.Combine ("path/to/unknown/project.csproj");
 
 		// Act & Assert
-		Assert.Throws<InvalidOperationException> (() => Scripts.GetTargetFrameworksFromProject (new FileSystem (), csproj));
+		Assert.Throws<InvalidOperationException> (() => Scripts.GetTargetFrameworksFromProject (csproj));
 	}
 }


### PR DESCRIPTION
Rename methods to be more explicit
Removes usage of IFileSystem when method call ExecuteCommand since ExecuteCommand doesn't respect the IFileSystem.

Based on #115 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/116)