### PR TITLE
Add GH Action to FF merge PR's

### DIFF
--- a/.github/workflows/pr-fast-forward-merge.yml
+++ b/.github/workflows/pr-fast-forward-merge.yml
@@ -1,0 +1,143 @@
+name: Override Merge
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  setupFastForwardMerge:
+    runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requires permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
+    # Run only if
+    # 1. The comment was made on a PR.
+    # 2. The comment was made by @mcumming, @dalexsoto.
+    # 3. The comment starts with "/sudo merge" sans the quotes.
+	# 4. The comment contains either "--ff-only" or "--no-ff". The default is "--ff-only".
+    # 5. The PR is open.
+    if: |
+       github.event.issue.pull_request != '' && 
+       startswith(github.event.comment.body, '/sudo merge') &&
+       !github.event.issue.closed_at &&
+       github.event.issue.state == 'open' &&
+       ( 
+           github.event.comment.user.login == 'mcumming' ||
+           github.event.comment.user.login == 'dalexsoto'
+       )
+    outputs:
+      fast_forward: ${{ steps.parse_comment.outputs.fast_forward }}
+
+    steps:
+      - name: Parse Comment
+        id: parse_comment
+        shell: pwsh
+        run: |
+          Write-Host "Parsing $env:COMMENT"
+          ($botName, $command, $options) = [System.Text.RegularExpressions.Regex]::Split("$env:COMMENT", "\s+")
+
+          # Check if $options is null or empty and set default value
+          if ([string]::IsNullOrEmpty($options)) {
+              $options = '--ff-only'
+          }
+
+          # Validate that $options is one of the allowed values
+          if ($options -ne '--ff-only' -and $options -ne '--no-ff') {
+              Write-Error "Invalid option: $options. Allowed values are '--ff-only' or '--no-ff'."
+              # Equivalent to the deprecated ::set-output command: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs			  
+              [IO.File]::AppendAllText($env:GITHUB_OUTPUT, "message=Invalid option: ${options}.$([Environment]::NewLine)") 			  
+              exit 1
+          }
+          
+          Write-Host "GITHUB_OUTPUT: ${env:GITHUB_OUTPUT}"
+          [IO.File]::AppendAllText($env:GITHUB_OUTPUT, "fast_forward=${options}$([Environment]::NewLine)")
+        env:
+          COMMENT: "${{ github.event.comment.body }}"
+
+      # Post a failure message when any of the previous steps fail.
+      - name: Add failure comment to PR
+        if: ${{ failure() }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{repository}/issues/{issue_number}/comments
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          body: ${{ steps.parse_comment.outputs.message }} Allowed values are --ff-only or --no-ff.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  mergeFastForward:
+    needs: setupFastForwardMerge
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      contents: read
+      security-events: none
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Fetch all history so that we can rebase the PR.
+          token: ${{ secrets.GH_TOKEN }}
+
+      # Get details of the PR. The target and base branch. And also whether the PR can be merged in or not.
+      - name: Get PR details
+        uses: octokit/request-action@v2.x
+        id: get-pr-details
+        with:
+          route: GET /repos/{repository}/pulls/{pull_number}
+          repository: ${{ github.repository }}
+          pull_number: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # Merge (rebase) the PR if it is allowed.
+      - name: Merge the PR
+        id: merge-status
+        shell: bash
+        env:
+          MERGEABLE_STATUS: ${{ fromJson(steps.get-pr-details.outputs.data).mergeable_state }}
+          BASE_BRANCH: ${{ fromJson(steps.get-pr-details.outputs.data).base.ref }}
+          HEAD_BRANCH: ${{ fromJson(steps.get-pr-details.outputs.data).head.ref }}
+          FAST_FORWARD: ${{ needs.setupFastForwardMerge.outputs.fast_forward }}
+        run: |
+          if [ "$MERGEABLE_STATUS" = "clean" ]; then
+            git config --global user.email "<github-actions-sudo@xamarin.com>"
+            git config --global user.name "GitHub Actions SUDO"
+
+            git checkout $BASE_BRANCH
+            git pull origin $HEAD_BRANCH $FAST_FORWARD
+            git push origin $BASE_BRANCH
+
+            echo "::set-output name=message::'PR merged succesfully.'"
+          else
+            echo "::set-output name=message::'PR cannot be merged.'"
+          fi
+
+      # Post a success/failure comment to the PR.
+      - name: Add comment to PR
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{repository}/issues/{issue_number}/comments
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          body: ${{ steps.merge-status.outputs.message }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      # Post a failure message when any of the previous steps fail.
+      - name: Add failure comment to PR
+        if: ${{ failure() }}
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{repository}/issues/{issue_number}/comments
+          repository: ${{ github.repository }}
+          issue_number: ${{ github.event.issue.number }}
+          body: ${{ steps.merge-status.outputs.message }} Check the Actions execution tab for details.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/pr-fast-forward-merge.yml
+++ b/.github/workflows/pr-fast-forward-merge.yml
@@ -18,7 +18,7 @@ jobs:
     # 1. The comment was made on a PR.
     # 2. The comment was made by @mcumming, @dalexsoto.
     # 3. The comment starts with "/sudo merge" sans the quotes.
-	# 4. The comment contains either "--ff-only" or "--no-ff". The default is "--ff-only".
+    # 4. The comment contains either "--ff-only" or "--no-ff". The default is "--ff-only".
     # 5. The PR is open.
     if: |
        github.event.issue.pull_request != '' && 


### PR DESCRIPTION
**Usage:**
`/sudo merge [--ff-only|--no-ff]`

**Options:**
  `--ff-only` : update to the new history if there is no divergent local history
  `--no-ff` : create a merge commit in all cases, even when the merge could instead be resolved as a fast-forward, this is the same as the `Create a merge commit` option in the GitHub Web UI.

If no fast forward option is provided, then `--ff-only` is used as the default.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/121)