### PR TITLE
ensure full project path is used

### DIFF
--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -21,7 +21,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 	public const string NO = nameof (NO);
 
 	protected SyncDirection SyncDirection { get; } = Direction;
-	protected string ProjectDir => FileSystem.Path.GetDirectoryName (ProjectPath)!;
+	protected string ProjectDir => FileSystem.Path.GetDirectoryName (FileSystem.Path.GetFullPath(ProjectPath))!;
 
 	public async Task SyncAsync (CancellationToken token = default)
 	{

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -21,7 +21,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 	public const string NO = nameof (NO);
 
 	protected SyncDirection SyncDirection { get; } = Direction;
-	protected string ProjectDir => FileSystem.Path.GetDirectoryName (FileSystem.Path.GetFullPath(ProjectPath))!;
+	protected string ProjectDir => FileSystem.Path.GetDirectoryName (FileSystem.Path.GetFullPath (ProjectPath))!;
 
 	public async Task SyncAsync (CancellationToken token = default)
 	{

--- a/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
@@ -54,6 +54,53 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 
 
 	[Theory]
+	[InlineData ("macos", "net8.0-macos")]
+	[InlineData ("maccatalyst", "net8.0-maccatalyst")]
+	[InlineData ("ios", "net8.0-ios")]
+	[InlineData ("tvos", "net8.0-tvos")]
+	[InlineData ("maui", "net8.0-ios")]
+	[InlineData ("maui", "net8.0-maccatalyst")]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task GenerateThenSyncFromProjectDir (string projectType, string tfm)
+	{
+		// Arrange
+
+		var projectName = Guid.NewGuid ().ToString ();
+
+		var tmpDir = Cache.CreateTemporaryDirectory (projectName);
+
+		var xcodeDir = Path.Combine ("obj", "xcode");
+
+		Directory.CreateDirectory (Path.Combine (tmpDir, xcodeDir));
+
+		var csproj = $"{projectName}.csproj";
+
+		await Git (TestOutput, "init", tmpDir).ConfigureAwait (false);
+		await DotnetNew (TestOutput, "gitignore", tmpDir, string.Empty).ConfigureAwait (false);
+		await DotnetNew (TestOutput, "editorconfig", tmpDir, string.Empty).ConfigureAwait (false);
+		await DotnetNew (TestOutput, "nugetconfig", tmpDir, string.Empty).ConfigureAwait (false);
+		await DotnetNew (TestOutput, projectType, tmpDir, string.Empty).ConfigureAwait (false);
+		await DotnetFormat (TestOutput, tmpDir).ConfigureAwait (false);
+		await Git (TestOutput, "-C", tmpDir, "add", ".").ConfigureAwait (false);
+		await Git (TestOutput, "-C", tmpDir, "commit", "-m", "Initial commit").ConfigureAwait (false);
+
+		// Act
+		var originalDirectory = Directory.GetCurrentDirectory ();
+		Directory.SetCurrentDirectory (tmpDir);
+
+		await Xcsync (TestOutput, "generate", "--project", csproj, "--target", xcodeDir, "-tfm", tfm).ConfigureAwait (false);
+		await Xcsync (TestOutput, "sync", "--project", csproj, "--target", xcodeDir, "-tfm", tfm).ConfigureAwait (false);
+
+		Directory.SetCurrentDirectory (originalDirectory);
+		// Assert
+		var commandOutput = new CaptureOutput (TestOutput);
+		var changesPresent = await Git (commandOutput, "-C", tmpDir, "diff", "-w", "--exit-code", "--").ConfigureAwait (false);
+		if (changesPresent == 1)
+			Assert.Fail ($"Git diff failed, there are changes in the source files.\n{commandOutput.Output}");
+	}
+
+
+	[Theory]
 	[InlineData ("https://github.com/haritha-mohan/vision-analyzer", new [] { "VisionAnalyzer/VisionAnalyzer.csproj" })]
 	[Trait ("Category", "IntegrationTest")]
 	public async Task GenerateThenSyncFromGitRepo_WithNoChanges_GeneratesNoChangesAsync (string repoUrl, string [] projects)

--- a/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
@@ -61,7 +61,8 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 	[InlineData ("maui", "net8.0-ios")]
 	[InlineData ("maui", "net8.0-maccatalyst")]
 	[Trait ("Category", "IntegrationTest")]
-	public async Task GenerateThenSyncFromProjectDir (string projectType, string tfm)
+    // Issue #123 : https://github.com/dotnet/xcsync/issues/123
+	public async Task GenerateThenSync_WhenPwdIsProjectDir_DoesNotThrow (string projectType, string tfm)
 	{
 		// Arrange
 

--- a/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
@@ -61,7 +61,7 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 	[InlineData ("maui", "net8.0-ios")]
 	[InlineData ("maui", "net8.0-maccatalyst")]
 	[Trait ("Category", "IntegrationTest")]
-    // Issue #123 : https://github.com/dotnet/xcsync/issues/123
+	// Issue #123 : https://github.com/dotnet/xcsync/issues/123
 	public async Task GenerateThenSync_WhenPwdIsProjectDir_DoesNotThrow (string projectType, string tfm)
 	{
 		// Arrange


### PR DESCRIPTION
fixes https://github.com/dotnet/xcsync/issues/123
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/125)


e2e test output since disabled on CI:

> Passed xcsync.e2e.tests.UseCases.GenerateThenSyncWithNoChangesTests.GenerateFromProjectDir(projectType: "maui", tfm: "net8.0-maccatalyst") [18 s]
> Passed xcsync.e2e.tests.UseCases.GenerateThenSyncWithNoChangesTests.GenerateFromProjectDir(projectType: "maccatalyst", tfm: "net8.0-maccatalyst") [17 s]
> Passed xcsync.e2e.tests.UseCases.GenerateThenSyncWithNoChangesTests.GenerateFromProjectDir(projectType: "macos", tfm: "net8.0-macos") [19 s]
> Passed xcsync.e2e.tests.UseCases.GenerateThenSyncWithNoChangesTests.GenerateFromProjectDir(projectType: "tvos", tfm: "net8.0-tvos") [17 s]
> Passed xcsync.e2e.tests.UseCases.GenerateThenSyncWithNoChangesTests.GenerateFromProjectDir(projectType: "ios", tfm: "net8.0-ios") [16 s]