### PR TITLE
fix regex anchors

### DIFF
--- a/src/xcsync/ExtensionFilter.cs
+++ b/src/xcsync/ExtensionFilter.cs
@@ -5,7 +5,7 @@ public interface IFilesystemEventFilter {
 	bool ProcessRenameEvent (string origin, string destination);
 }
 
-public class ExtensionFilter (params string[] extensionsToMonitor) : IFilesystemEventFilter {
+public class ExtensionFilter (params string [] extensionsToMonitor) : IFilesystemEventFilter {
 	readonly HashSet<string> _extensionsToMonitor = new (extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
 
 	public bool ProcessEvent (string path)

--- a/src/xcsync/ExtensionFilter.cs
+++ b/src/xcsync/ExtensionFilter.cs
@@ -1,0 +1,26 @@
+namespace xcsync;
+#pragma warning disable IO0006 // Replace Path class with IFileSystem.Path for improved testability
+public interface IFilesystemEventFilter
+{
+    bool ProcessEvent(string path); // You will have to list each event
+    bool ProcessRenameEvent(string origin, string destination);
+}
+
+public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesystemEventFilter
+{
+    readonly HashSet<string> _extensionsToMonitor = new HashSet<string> (extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
+
+	public bool ProcessEvent(string path)
+    {
+        var extension = Path.GetExtension(path);
+        return _extensionsToMonitor.Contains(extension);
+    }
+
+    public bool ProcessRenameEvent(string origin, string destination)
+    {
+		var originExtension = Path.GetExtension(origin);
+		var destinationExtension = Path.GetExtension(destination);
+        return _extensionsToMonitor.Contains(originExtension) || _extensionsToMonitor.Contains(destinationExtension);
+    }
+}
+#pragma warning restore IO0006 // Replace Path class with IFileSystem.Path for improved testability

--- a/src/xcsync/ExtensionFilter.cs
+++ b/src/xcsync/ExtensionFilter.cs
@@ -1,27 +1,25 @@
 namespace xcsync;
 #pragma warning disable IO0006 // Replace Path class with IFileSystem.Path for improved testability
-public interface IFilesystemEventFilter
-{
-    bool ProcessEvent(string path); // You will have to list each event
-    bool ProcessRenameEvent(string origin, string destination);
+public interface IFilesystemEventFilter {
+	bool ProcessEvent (string path); // You will have to list each event
+	bool ProcessRenameEvent (string origin, string destination);
 }
 
-public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesystemEventFilter
-{
-    readonly HashSet<string> _extensionsToMonitor = new(extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
+public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesystemEventFilter {
+	readonly HashSet<string> _extensionsToMonitor = new (extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
 
-	public bool ProcessEvent(string path)
-    {
-        var extension = Path.GetExtension(path);
-        return _extensionsToMonitor.Contains(extension);
-    }
+	public bool ProcessEvent (string path)
+	{
+		var extension = Path.GetExtension (path);
+		return _extensionsToMonitor.Contains (extension);
+	}
 
-    public bool ProcessRenameEvent(string origin, string destination)
-    {
-		var originExtension = Path.GetExtension(origin);
-		var destinationExtension = Path.GetExtension(destination);
-        return _extensionsToMonitor.Contains(originExtension) || _extensionsToMonitor.Contains(destinationExtension);
-    }
+	public bool ProcessRenameEvent (string origin, string destination)
+	{
+		var originExtension = Path.GetExtension (origin);
+		var destinationExtension = Path.GetExtension (destination);
+		return _extensionsToMonitor.Contains (originExtension) || _extensionsToMonitor.Contains (destinationExtension);
+	}
 
 	public string GetExtensionsToMonitorAsString () => string.Join (", ", _extensionsToMonitor.Select (ext => ext));
 }

--- a/src/xcsync/ExtensionFilter.cs
+++ b/src/xcsync/ExtensionFilter.cs
@@ -5,7 +5,7 @@ public interface IFilesystemEventFilter {
 	bool ProcessRenameEvent (string origin, string destination);
 }
 
-public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesystemEventFilter {
+public class ExtensionFilter (params string[] extensionsToMonitor) : IFilesystemEventFilter {
 	readonly HashSet<string> _extensionsToMonitor = new (extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
 
 	public bool ProcessEvent (string path)
@@ -21,6 +21,6 @@ public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesy
 		return _extensionsToMonitor.Contains (originExtension) || _extensionsToMonitor.Contains (destinationExtension);
 	}
 
-	public string GetExtensionsToMonitorAsString () => string.Join (", ", _extensionsToMonitor.Select (ext => ext));
+	public string GetExtensionsToMonitorAsString () => string.Join (", ", _extensionsToMonitor);
 }
 #pragma warning restore IO0006 // Replace Path class with IFileSystem.Path for improved testability

--- a/src/xcsync/ExtensionFilter.cs
+++ b/src/xcsync/ExtensionFilter.cs
@@ -8,7 +8,7 @@ public interface IFilesystemEventFilter
 
 public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesystemEventFilter
 {
-    readonly HashSet<string> _extensionsToMonitor = new HashSet<string> (extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
+    readonly HashSet<string> _extensionsToMonitor = new(extensionsToMonitor, StringComparer.OrdinalIgnoreCase);
 
 	public bool ProcessEvent(string path)
     {
@@ -22,5 +22,7 @@ public class ExtensionFilter (IEnumerable<string> extensionsToMonitor) : IFilesy
 		var destinationExtension = Path.GetExtension(destination);
         return _extensionsToMonitor.Contains(originExtension) || _extensionsToMonitor.Contains(destinationExtension);
     }
+
+	public string GetExtensionsToMonitorAsString () => string.Join (", ", _extensionsToMonitor.Select (ext => ext));
 }
 #pragma warning restore IO0006 // Replace Path class with IFileSystem.Path for improved testability

--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
-using System.Text.RegularExpressions;
 using Serilog;
 
 namespace xcsync;
@@ -68,7 +67,7 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 		_extensionFilter = project.ProjectFilesFilter;
 
-		logger.Debug (Strings.Watch.FileChangeFilter (_extensionFilter.ToString ()!));
+		logger.Information (Strings.Watch.FileChangeFilter (_extensionFilter.GetExtensionsToMonitorAsString()));
 	}
 
 	/// <summary>

--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -67,11 +67,17 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 		watcher.EnableRaisingEvents = true;
 
-		var filters = string.Join ("|", this.project.ProjectFilesFilter.Select (f => f.Replace (".", @"\.").Replace ("*", ".*").Replace ("?", ".?")));
-		if (string.IsNullOrEmpty (filters))
-			filters = ".*";
-		fileFilterRegex = new Regex ($"^{filters}$", RegexOptions.IgnoreCase);
-		logger.Debug (Strings.Watch.FileChangeFilter (fileFilterRegex.ToString ()));
+		var filters = this.project
+						.ProjectFilesFilter
+						.Any()
+						? string.Join("|", this.project.ProjectFilesFilter
+														.Select(f => $"^{Regex
+														.Escape(f)
+														.Replace("\\*", ".*")
+														.Replace("\\?", ".?")}$"))
+						: ".*";
+		fileFilterRegex = new Regex(filters, RegexOptions.IgnoreCase);
+		logger.Debug(Strings.Watch.FileChangeFilter(fileFilterRegex.ToString()));
 	}
 
 	/// <summary>

--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -67,7 +67,7 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 		_extensionFilter = project.ProjectFilesFilter;
 
-		logger.Information (Strings.Watch.FileChangeFilter (_extensionFilter.GetExtensionsToMonitorAsString()));
+		logger.Information (Strings.Watch.FileChangeFilter (_extensionFilter.GetExtensionsToMonitorAsString ()));
 	}
 
 	/// <summary>

--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -69,15 +69,15 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 		var filters = this.project
 						.ProjectFilesFilter
-						.Any()
-						? string.Join("|", this.project.ProjectFilesFilter
-														.Select(f => $"^{Regex
-														.Escape(f)
-														.Replace("\\*", ".*")
-														.Replace("\\?", ".?")}$"))
+						.Any ()
+						? string.Join ("|", this.project.ProjectFilesFilter
+														.Select (f => $"^{Regex
+														.Escape (f)
+														.Replace ("\\*", ".*")
+														.Replace ("\\?", ".?")}$"))
 						: ".*";
-		fileFilterRegex = new Regex(filters, RegexOptions.IgnoreCase);
-		logger.Debug(Strings.Watch.FileChangeFilter(fileFilterRegex.ToString()));
+		fileFilterRegex = new Regex (filters, RegexOptions.IgnoreCase);
+		logger.Debug (Strings.Watch.FileChangeFilter (fileFilterRegex.ToString ()));
 	}
 
 	/// <summary>

--- a/src/xcsync/ProjectFileChangeMonitor.cs
+++ b/src/xcsync/ProjectFileChangeMonitor.cs
@@ -39,7 +39,7 @@ class ProjectFileChangeMonitor (IFileSystem fileSystem, IFileSystemWatcher fileS
 
 	bool disposedValue;
 
-	ExtensionFilter _extensionFilter = new (["."]);
+	ExtensionFilter _extensionFilter = new (".");
 
 	/// <summary>
 	/// Starts monitoring the project file changes.

--- a/src/xcsync/Projects/ClrProject.cs
+++ b/src/xcsync/Projects/ClrProject.cs
@@ -9,7 +9,7 @@ using Serilog;
 namespace xcsync.Projects;
 
 class ClrProject (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework)
-	: SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, ["*.cs", "*.csproj", "*.sln"]) {
+	: SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter ([".cs", ".csproj", ".sln"])) {
 
 	public bool IsMauiApp { get; private set; }
 

--- a/src/xcsync/Projects/ClrProject.cs
+++ b/src/xcsync/Projects/ClrProject.cs
@@ -9,7 +9,7 @@ using Serilog;
 namespace xcsync.Projects;
 
 class ClrProject (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework)
-	: SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter ([".cs", ".csproj", ".sln"])) {
+	: SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter (".cs", ".csproj", ".sln")) {
 
 	public bool IsMauiApp { get; private set; }
 

--- a/src/xcsync/Projects/ISyncableProject.cs
+++ b/src/xcsync/Projects/ISyncableProject.cs
@@ -6,5 +6,5 @@ namespace xcsync;
 interface ISyncableProject {
 	string Name { get; }
 	string RootPath { get; }
-	string [] ProjectFilesFilter { get; }
+	ExtensionFilter ProjectFilesFilter { get; }
 }

--- a/src/xcsync/Projects/SyncableProject.cs
+++ b/src/xcsync/Projects/SyncableProject.cs
@@ -12,7 +12,7 @@ class SyncableProject : ISyncableProject {
 
 	public string RootPath { get; init; }
 
-	public string [] ProjectFilesFilter { get; init; }
+	public ExtensionFilter ProjectFilesFilter { get; init; }
 
 	protected IFileSystem FileSystem { get; init; }
 
@@ -24,7 +24,7 @@ class SyncableProject : ISyncableProject {
 
 	Task? initTask;
 
-	public SyncableProject (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string rootPath, string framework, string [] projectFilesFilter)
+	public SyncableProject (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string rootPath, string framework, ExtensionFilter projectFilesFilter)
 	{
 		FileSystem = fileSystem;
 		Logger = logger;

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -23,7 +23,7 @@ using static ClangSharp.Interop.CXTranslationUnit_Flags;
 namespace xcsync.Projects;
 
 partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework) :
-	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter (["*.pbxproj", "*.m", "*.h", "*.storyboard"])) {
+	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter ([".pbxproj", ".m", ".h", ".storyboard"])) {
 
 	static CXIndex cxIndex = CXIndex.Create ();
 

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -23,7 +23,7 @@ using static ClangSharp.Interop.CXTranslationUnit_Flags;
 namespace xcsync.Projects;
 
 partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework) :
-	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, ["*.xcodeproj", "*.m", "*.h", "*.storyboard"]) {
+	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter (["*.pbxproj", "*.m", "*.h", "*.storyboard"])) {
 
 	static CXIndex cxIndex = CXIndex.Create ();
 

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -23,7 +23,7 @@ using static ClangSharp.Interop.CXTranslationUnit_Flags;
 namespace xcsync.Projects;
 
 partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework) :
-	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter ([".pbxproj", ".m", ".h", ".storyboard"])) {
+	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter (".pbxproj", ".m", ".h", ".storyboard")) {
 
 	static CXIndex cxIndex = CXIndex.Create ();
 

--- a/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
+++ b/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
@@ -20,6 +20,7 @@ public class ProjectFileChangeMonitorTests {
 		watcher = Mock.Of<IFileSystemWatcher> ();
 		logger = Mock.Of<ILogger> ();
 		project = Mock.Of<ISyncableProject> ();
+		Mock.Get (project).Setup (p=> p.ProjectFilesFilter).Returns (new ExtensionFilter ([".cs", ".resx", ".File"]));
 		fileSystem = Mock.Of<IFileSystem> ();
 		Mock.Get (fileSystem).Setup (fs => fs.Path.GetDirectoryName (project.RootPath)).Returns ("/repos/repo/project");
 
@@ -51,12 +52,12 @@ public class ProjectFileChangeMonitorTests {
 	}
 
 	[Theory]
-	[InlineData (new string [] { }, @"/repos/repo/project/src", "Some.File")]
-	[InlineData (new string [] { "*.resx", "*.cs" }, @"/repos/repo/project/src", "Some.File.cs")]
-	[InlineData (new string [] { "*/Resources/*.resx", "*.cs" }, @"/repos/repo/project/src/Resources", "Some.File.resx")]
+	[InlineData (new string [] {".File" }, @"/repos/repo/project/src", "Some.File")]
+	[InlineData (new string [] { ".resx", ".cs" }, @"/repos/repo/project/src", "Some.File.cs")]
+	[InlineData (new string [] { ".resx", ".cs" }, @"/repos/repo/project/src/Resources", "Some.File.resx")]
 	public void OnFileChanged_ShouldBeCalled_WhenFileChangesDetected (string [] fileFilter, string filePath, string fileName)
 	{
-		var project = Mock.Of<ISyncableProject> (p => p.ProjectFilesFilter == fileFilter);
+		var project = Mock.Of<ISyncableProject> (p => p.ProjectFilesFilter == new ExtensionFilter (fileFilter));
 
 		var fileChanged = false;
 		monitor.OnFileChanged =

--- a/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
+++ b/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
@@ -20,7 +20,7 @@ public class ProjectFileChangeMonitorTests {
 		watcher = Mock.Of<IFileSystemWatcher> ();
 		logger = Mock.Of<ILogger> ();
 		project = Mock.Of<ISyncableProject> ();
-		Mock.Get (project).Setup (p=> p.ProjectFilesFilter).Returns (new ExtensionFilter ([".cs", ".resx", ".File"]));
+		Mock.Get (project).Setup (p => p.ProjectFilesFilter).Returns (new ExtensionFilter ([".cs", ".resx", ".File"]));
 		fileSystem = Mock.Of<IFileSystem> ();
 		Mock.Get (fileSystem).Setup (fs => fs.Path.GetDirectoryName (project.RootPath)).Returns ("/repos/repo/project");
 

--- a/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
+++ b/test/xcsync.tests/ProjectFileChangeMonitorTests.cs
@@ -52,13 +52,11 @@ public class ProjectFileChangeMonitorTests {
 	}
 
 	[Theory]
-	[InlineData (new string [] {".File" }, @"/repos/repo/project/src", "Some.File")]
-	[InlineData (new string [] { ".resx", ".cs" }, @"/repos/repo/project/src", "Some.File.cs")]
-	[InlineData (new string [] { ".resx", ".cs" }, @"/repos/repo/project/src/Resources", "Some.File.resx")]
-	public void OnFileChanged_ShouldBeCalled_WhenFileChangesDetected (string [] fileFilter, string filePath, string fileName)
+	[InlineData (@"/repos/repo/project/src", "Some.File")]
+	[InlineData (@"/repos/repo/project/src", "Some.File.cs")]
+	[InlineData (@"/repos/repo/project/src/Resources", "Some.File.resx")]
+	public void OnFileChanged_ShouldBeCalled_WhenFileChangesDetected (string filePath, string fileName)
 	{
-		var project = Mock.Of<ISyncableProject> (p => p.ProjectFilesFilter == new ExtensionFilter (fileFilter));
-
 		var fileChanged = false;
 		monitor.OnFileChanged =
 			path => fileChanged = true;


### PR DESCRIPTION
this is to prevent behavior like the following from causing unnecessary Xcode generation events:

> [21:58:15 INF xcsync (31)] File renamed from /Users/harithamohan/src/Repro/obj/4617e038-ab20-425e-ab16-2d59b10ce9db.tmp to /Users/harithamohan/src/Repro/obj/Repro.csproj.nuget.g.props in CLR project.

the path of concern:
/Users/harithamohan/src/Repro/obj/Repro.**csproj**.nuget.g.props contains the .csproj extension but does not end with it; therefore, it should not be subject to monitoring.

the regex anchors need to be applied to each extension entity rather than the entire regex as a whole.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/126)