### PR TITLE
Add all NSObject-derived types to TypeSystem

### DIFF
--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -142,10 +142,9 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			logger.Debug ($"[{nameof (ObjCSyntaxRewriter)}] Parsing property type '{objcProperty.Type.AsString}'");
 			// TODO: This is a *very* primitive way to get the property type and will need improvement
 			// TODO: Need a solution to handle the case where the property type is not found  or is null in the type mapping
-			var propertyType = objcProperty.Type switch { 
-				{ Kind: CXType_ObjCObjectPointer } => typeService
-					.QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
-					.First()?.ClrType ?? string.Empty,
+			var propertyType = objcProperty.Type switch { { Kind: CXType_ObjCObjectPointer } => typeService
+															  .QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
+															  .First ()?.ClrType ?? string.Empty,
 				_ => throw new NotImplementedException ($"Unsupported property type {objcProperty.Type.KindSpelling}")
 			};
 

--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -139,9 +139,13 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 
 			var propertyName = objcProperty.Name;
 
+			logger.Debug ($"[{nameof (ObjCSyntaxRewriter)}] Parsing property type '{objcProperty.Type.AsString}'");
 			// TODO: This is a *very* primitive way to get the property type and will need improvement
 			// TODO: Need a solution to handle the case where the property type is not found  or is null in the type mapping
-			var propertyType = objcProperty.Type switch { { Kind: CXType_ObjCObjectPointer } => typeService.QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0]).First ()?.ClrType ?? string.Empty,
+			var propertyType = objcProperty.Type switch { 
+				{ Kind: CXType_ObjCObjectPointer } => typeService
+					.QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
+					.First()?.ClrType ?? string.Empty,
 				_ => throw new NotImplementedException ($"Unsupported property type {objcProperty.Type.KindSpelling}")
 			};
 

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -156,7 +156,7 @@ class TypeService (ILogger Logger) : ITypeService {
 		// limit scope of namespaces to only those that conatin NSObject derived types.
 		var namespaces = compilation.GlobalNamespace.GetNamespaceMembers ()
 			.Where (ns => ns.GetTypeMembers ()
-				.Any(xcSync.IsNsoDerived));
+				.Any (xcSync.IsNsoDerived));
 
 		if (namespaces is null)
 			return;

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -153,11 +153,10 @@ class TypeService (ILogger Logger) : ITypeService {
 
 	void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
 	{
-		// limit scope of namespaces to project, do not include referenced assemblies, etc.
+		// limit scope of namespaces to only those that conatin NSObject derived types.
 		var namespaces = compilation.GlobalNamespace.GetNamespaceMembers ()
-			.Where (ns => ns.GetMembers ()
-				.Any (member => member.Locations
-					.Any (location => location.IsInSource)));
+			.Where (ns => ns.GetTypeMembers ()
+				.Any(xcSync.IsNsoDerived));
 
 		if (namespaces is null)
 			return;
@@ -166,7 +165,7 @@ class TypeService (ILogger Logger) : ITypeService {
 			foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
 				var nsType = ConvertToTypeMapping (targetPlatform, type);
 				if (nsType is not null) {
-					AddType (nsType with { IsInSource = true });
+					AddType (nsType with { IsInSource = type.Locations.Any (l => l.IsInSource) });
 				}
 			}
 		}

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -153,7 +153,7 @@ class TypeService (ILogger Logger) : ITypeService {
 
 	void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
 	{
-		// limit scope of namespaces to only those that conatin NSObject derived types.
+		// limit scope of namespaces to only those that contain NSObject derived types.
 		var namespaces = compilation.GlobalNamespace.GetNamespaceMembers ()
 			.Where (ns => ns.GetTypeMembers ()
 				.Any (xcSync.IsNsoDerived));

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -113,8 +113,9 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		};
 		xcodeObjects.Add (pbxGroup.Token, pbxGroup);
 
-		foreach (var t in TypeService.QueryTypes ()) {
-			if (t is null) continue;
+		foreach (var t in TypeService.QueryTypes ().Where (t => t is not null && t.IsInSource)) {
+
+			if (t is null) continue; // Only needed to keep the compiler happy
 
 			// all NSObjects get a corresponding .h + .m file generated
 			// generated .h + .m files are added to the xcode project deps

--- a/test/xcsync.e2e.tests/Base.cs
+++ b/test/xcsync.e2e.tests/Base.cs
@@ -43,7 +43,7 @@ public class Base (ITestOutputHelper testOutput) {
 			standardOutput: outputWrapper,
 			standardError: outputWrapper,
 			log: outputWrapper,
-			timeout: TimeSpan.FromSeconds (10)
+			timeout: TimeSpan.FromSeconds (30)
 		).ConfigureAwait (false);
 		return exec.ExitCode;
 	}

--- a/test/xcsync.tests/Projects/DotnetTest.cs
+++ b/test/xcsync.tests/Projects/DotnetTest.cs
@@ -35,7 +35,7 @@ public class DotnetTest (ITestOutputHelper TestOutput) : Base {
 		try {
 			var project = await clrProject.OpenProject ().ConfigureAwait (false);
 			var types = typeService.QueryTypes ().ToList ();
-			Assert.Equal (expectedTypes, [.. types.Where (x => x?.ClrType is not null).Select (x => x?.ClrType).OrderBy (x => x)]);
+			Assert.Equal (expectedTypes, [.. types.Where (x => x is not null && x.ClrType is not null & x.IsInSource).Select (x => x?.ClrType).OrderBy (x => x)]);
 		} catch (Exception ex) when (ex.Message.Contains ("MSBuildLocator.RegisterInstance")) {
 			Assert.Fail ($"System issue encountered: {ex.Message}. This failure is unrelated to the actual test. " +
 						"Ensure that MSBuild assemblies are not pre-loaded before running the tests. " +

--- a/test/xcsync.tests/Projects/DotnetTest.cs
+++ b/test/xcsync.tests/Projects/DotnetTest.cs
@@ -35,7 +35,7 @@ public class DotnetTest (ITestOutputHelper TestOutput) : Base {
 		try {
 			var project = await clrProject.OpenProject ().ConfigureAwait (false);
 			var types = typeService.QueryTypes ().ToList ();
-			Assert.Equal (expectedTypes, [.. types.Where (x => x is not null && x.ClrType is not null & x.IsInSource).Select (x => x?.ClrType).OrderBy (x => x)]);
+			Assert.Equal (expectedTypes, [.. types.Where (x => x is not null && x.ClrType is not null && x.IsInSource).Select (x => x?.ClrType).OrderBy (x => x)]);
 		} catch (Exception ex) when (ex.Message.Contains ("MSBuildLocator.RegisterInstance")) {
 			Assert.Fail ($"System issue encountered: {ex.Message}. This failure is unrelated to the actual test. " +
 						"Ensure that MSBuild assemblies are not pre-loaded before running the tests. " +

--- a/test/xcsync.tests/Projects/NSProjectTest.cs
+++ b/test/xcsync.tests/Projects/NSProjectTest.cs
@@ -23,7 +23,7 @@ public class NSProjectTest : Base {
 
 		(_, ITypeService typeService) = InitializeProjects ();
 
-		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol & t.IsInSource).Select (t => t?.ClrType).OrderBy (t => t));
+		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol && t.IsInSource).Select (t => t?.ClrType).OrderBy (t => t));
 	}
 
 	[InlineData ("ModelVariety", "ObjectiveCModelVariety", true, false, "NSObject", "NSObject", false)]

--- a/test/xcsync.tests/Projects/NSProjectTest.cs
+++ b/test/xcsync.tests/Projects/NSProjectTest.cs
@@ -23,7 +23,7 @@ public class NSProjectTest : Base {
 
 		(_, ITypeService typeService) = InitializeProjects ();
 
-		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol &t.IsInSource).Select (t => t?.ClrType).OrderBy (t => t));
+		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol & t.IsInSource).Select (t => t?.ClrType).OrderBy (t => t));
 	}
 
 	[InlineData ("ModelVariety", "ObjectiveCModelVariety", true, false, "NSObject", "NSObject", false)]

--- a/test/xcsync.tests/Projects/NSProjectTest.cs
+++ b/test/xcsync.tests/Projects/NSProjectTest.cs
@@ -23,7 +23,7 @@ public class NSProjectTest : Base {
 
 		(_, ITypeService typeService) = InitializeProjects ();
 
-		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol).Select (t => t?.ClrType).OrderBy (t => t));
+		Assert.Equal (expectedTypes, typeService.QueryTypes ().ToList ().Where (t => t?.ClrType is not null && !t.IsProtocol &t.IsInSource).Select (t => t?.ClrType).OrderBy (t => t));
 	}
 
 	[InlineData ("ModelVariety", "ObjectiveCModelVariety", true, false, "NSObject", "NSObject", false)]


### PR DESCRIPTION
This allows the ObjCSyntaxRewriter to find framework types in order to generate the correct C#.

Fixes #141 

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/140)