### PR TITLE
fix path for maui items

### DIFF
--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -500,7 +500,8 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 			await (syncItem switch {
 #pragma warning disable CA2012 // Use ValueTasks correctly  
 				SyncableType type => Hub.PublishAsync (SyncChannel, new LoadTypesFromObjCMessage (Guid.NewGuid ().ToString (), tcs = new TaskCompletionSource (), xcodeWorkspace, syncItem)),
-				SyncableContent file => Hub.PublishAsync (FileChannel, new CopyFileMessage (Guid.NewGuid ().ToString (), file.SourcePath, FileSystem.Path.Combine (ProjectDir!, FileSystem.Path.Combine (basePath, file.DestinationPath)))),
+				SyncableContent file when string.IsNullOrEmpty (basePath) => Hub.PublishAsync (FileChannel, new CopyFileMessage (Guid.NewGuid ().ToString (), file.SourcePath, FileSystem.Path.Combine (ProjectDir!, FileSystem.Path.Combine (basePath, file.DestinationPath)))),
+				SyncableContent file => Hub.PublishAsync (FileChannel, new CopyFileMessage (Guid.NewGuid ().ToString (), file.SourcePath, FileSystem.Path.Combine (ProjectDir!, FileSystem.Path.Combine (basePath, FileSystem.Path.GetRelativePath (basePath, file.DestinationPath))))),
 				_ => ValueTask.CompletedTask
 #pragma warning restore CA2012 // Use ValueTasks correctly
 			}).ConfigureAwait (false);


### PR DESCRIPTION
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/142)

Addresses: (encountered when running sync on a MAUI proj)

Unhandled exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/harithamohan/p2/Platforms/MacCatalyst/Platforms/MacCatalyst/Entitlements.plist'.

path _should be_  '/Users/harithamohan/p2/Platforms/MacCatalyst/Entitlements.plist'.


before:

> [main][~/src/xamarin-macios/main/xcsync/artifacts/bin/xcsync/Debug/net8.0]$ ./xcsync sync -p /Users/harithamohan/yur/p1/p1.csproj -tfm net9.0-ios
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.
[16:45:19 INF xcsync (1)] Syncing files from project '/Users/harithamohan/yur/p1/obj/xcode' to target '/Users/harithamohan/yur/p1/p1.csproj'
[16:45:23 FTL xcsync (17)] Exception in ConsumeAsync: Could not find a part of the path '/Users/harithamohan/yur/p1/Platforms/iOS/Platforms/iOS/Info.plist'.
[16:45:23 INF xcsync (13)] Parsing '/Users/harithamohan/yur/p1/obj/xcode/AppDelegate.m' generated diagnostic messages use Detailed logging to view them.
[16:45:23 INF xcsync (13)] Processing '/Users/harithamohan/yur/p1/obj/xcode/AppDelegate.m'
[16:45:23 INF xcsync (13)] Found ObjCImplementationDecl: AppDelegate
[16:45:23 INF xcsync (13)] Processing ObjCImplementationDecl: AppDelegate
Unhandled exception: System.IO.DirectoryNotFoundException: Could not find a part of the path '/Users/harithamohan/yur/p1/Platforms/iOS/Platforms/iOS/Info.plist'.
   at System.IO.FileSystem.TryCloneFile(String sourceFullPath, String destFullPath, Boolean overwrite, Boolean& cloned)
   at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at System.IO.Abstractions.FileWrapper.Copy(String sourceFileName, String destFileName, Boolean overwrite)
   at xcsync.Workers.CopyFileWorker.ConsumeAsync(CopyFileMessage message, CancellationToken cancellationToken) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/Workers/FileWorker.cs:line 77
   at Marille.Hub.DeliverAtMostOnce[T](Channel`1 channel, IWorker`1[] workersArray, Message`1 item, Nullable`1 timeout) in /_/src/Marille/Hub.cs:line 91
   at Marille.Hub.ConsumeChannel[T](TopicConfiguration configuration, Channel`1 ch, IErrorWorker`1 errorWorker, IWorker`1[] workersArray, TaskCompletionSource`1 completionSource, CancellationToken cancellationToken) in /_/src/Marille/Hub.cs:line 143
   at Marille.TopicInfo`1.CloseChannel() in /_/src/Marille/TopicInfo.cs:line 69
   at Marille.TopicInfo`1.DisposeAsyncCore() in /_/src/Marille/TopicInfo.cs:line 90
   at Marille.TopicInfo.DisposeAsync() in /_/src/Marille/TopicInfo.cs:line 46
   at Marille.Topic.DisposeAsyncCore() in /_/src/Marille/Topic.cs:line 72
   at Marille.Topic.DisposeAsync() in /_/src/Marille/Topic.cs:line 78
   at Marille.Hub.CloseAllAsync() in /_/src/Marille/Hub.cs:line 321
   at xcsync.SyncContext.SyncAsync(CancellationToken token) in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/SyncContext.cs:line 35
   at xcsync.Commands.SyncCommand.Execute() in /Users/harithamohan/src/xamarin-macios/main/xcsync/src/xcsync/Commands/SyncCommand.cs:line 20
   at System.CommandLine.Invocation.AnonymousCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass4_0.<<BuildInvocationChain>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass17_0.<<UseParseErrorReporting>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass12_0.<<UseHelp>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass22_0.<<UseVersionOption>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass19_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<UseSuggestDirective>b__18_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass16_0.<<UseParseDirective>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<RegisterWithDotnetSuggest>b__5_0>d.MoveNext()
--- End of stack trace from previous location ---
   at System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()


after:

> [dev/haritha/fix-maui-path][~/src/xamarin-macios/main/xcsync/artifacts/bin/xcsync/Debug/net8.0]$ ./xcsync sync -p /Users/harithamohan/yur/p1/p1.csproj -tfm net9.0-ios       
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.
[17:01:02 INF xcsync (1)] Syncing files from project '/Users/harithamohan/yur/p1/obj/xcode' to target '/Users/harithamohan/yur/p1/p1.csproj'
[17:01:09 INF xcsync (9)] Copied /Users/harithamohan/yur/p1/obj/xcode/Platforms/iOS/Info.plist to /Users/harithamohan/yur/p1/Platforms/iOS/Info.plist
[17:01:09 INF xcsync (4)] Parsing '/Users/harithamohan/yur/p1/obj/xcode/AppDelegate.m' generated diagnostic messages use Detailed logging to view them.
[17:01:09 INF xcsync (4)] Processing '/Users/harithamohan/yur/p1/obj/xcode/AppDelegate.m'
[17:01:09 INF xcsync (4)] Found ObjCImplementationDecl: AppDelegate
[17:01:09 INF xcsync (4)] Processing ObjCImplementationDecl: AppDelegate