### PR TITLE
Add logging message for Xcode path used

### DIFF
--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Serilog;
 
@@ -72,6 +73,14 @@ class BaseCommand<T> : Command {
 	protected virtual void AddValidators ()
 	{
 		AddValidator ((result) => {
+
+			if (!RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+				result.ErrorMessage = Strings.Errors.Validation.InvalidOS;
+				return;
+			}
+
+			xcSync.XcodePath = Scripts.SelectXcode ();
+			Logger?.Information (Strings.Base.XcodePath (xcSync.XcodePath));
 
 			var validation = ValidateCommand (result);
 

--- a/src/xcsync/Commands/XcSyncCommand.cs
+++ b/src/xcsync/Commands/XcSyncCommand.cs
@@ -42,18 +42,12 @@ class XcSyncCommand : RootCommand {
 
 		SharedOptions.DotnetPath.AddValidator (result => {
 			xcSync.DotnetPath = result.GetValueForOption (SharedOptions.DotnetPath) ?? string.Empty;
-			Logger?.Debug ("Using the `dotnet` located at {0}", xcSync.DotnetPath);
+			Logger?.Information (Strings.Base.DotnetPath (xcSync.DotnetPath));
 		});
 
 		AddCommand (new GenerateCommand (fileSystem, Logger));
 		AddCommand (new SyncCommand (fileSystem, Logger));
 		if (!string.IsNullOrEmpty (Environment.GetEnvironmentVariable ("EnableXcsyncWatch")))
 			AddCommand (new WatchCommand (fileSystem, Logger));
-
-		AddValidator (result => {
-			if (!RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
-				result.ErrorMessage = Strings.Errors.Validation.InvalidOS;
-			}
-		});
 	}
 }

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -111,7 +111,7 @@ partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeServi
 			"-target",
 			$"arm64-apple-{sdk}",
 			"-isysroot",
-			FileSystem.Path.Combine (Scripts.SelectXcode (), "Contents", "Developer", "Platforms", $"{SdkRoot}.platform", "Developer", "SDKs", $"{SdkRoot}.sdk"),
+			FileSystem.Path.Combine (xcSync.XcodePath, "Contents", "Developer", "Platforms", $"{SdkRoot}.platform", "Developer", "SDKs", $"{SdkRoot}.sdk"),
 		]);
 
 		LoadSyncableItems (fileReferences, syncableItems);

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -54,7 +54,10 @@ static class Strings {
 		internal static string UseDefaultTfm => Resources.Strings.Base_UseDefaultTfm;
 		internal static string EstablishDefaultTarget (string path) => string.Format (Resources.Strings.Base_EstablishDefaultTarget, path);
 		internal static string CreateDefaultTarget (string path) => string.Format (Resources.Strings.Base_CreateDefaultTarget, path);
+		internal static string DotnetPath (string path) => string.Format (Resources.Strings.Base_DotnetPath, path);
+		internal static string XcodePath (string path) => string.Format (Resources.Strings.Base_XcodePath, path);
 	}
+	
 	internal static class Generate {
 		internal static string HeaderInformation => Resources.Strings.Generate_HeaderInformation;
 		internal static string GeneratedFiles => Resources.Strings.Generate_GeneratedFiles;

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -242,6 +242,14 @@
 		<value>Target path '{0}' does not exist, but is the default location, creating.</value>
 		<comment>{0} is the path to target project</comment>
 	</data>
+	<data name="Base.DotnetPath" xml:space="preserve">
+		<value>Using the `dotnet` located at {0}.</value>
+		<comment>{0} is the path to dotnet</comment>
+	</data>
+	<data name="Base.XcodePath" xml:space="preserve">
+		<value>Using Xcode from {0}.</value>
+		<comment>{0} is the path to Xcode</comment>
+	</data>
 
 	<!-- Generate Messages -->
 	<data name="Generate.HeaderInformation" xml:space="preserve">

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Cílová cesta {0} neexistuje, ale je výchozím umístěním. Probíhá vytváření.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Cílová cesta je výchozí umístění nebo je prázdná. Přidává se předpona {0}.</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Nebyl zadán žádný moniker cílové architektury. Použije se první moniker nalezený v projektu.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Der Zielpfad "{0}" ist nicht vorhanden, ist aber der Standardspeicherort, der erstellt wird.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Der Zielpfad ist der Standardspeicherort oder leer, wobei "{0}" als Präfix vorangestellt wird.</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Es wurde kein Zielframeworkmoniker angegeben, und der erste im Projekt gefundene wird verwendet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La ruta de acceso de destino '{0}' no existe, sino que es la ubicación predeterminada, creando.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">La ruta de acceso de destino es la ubicación predeterminada o está vacía, con el prefijo '{0}'</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">No se ha especificado ningún moniker de la plataforma de destino, se está usando el primero encontrado en el proyecto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Le chemin d’accès cible « {0} » n’existe pas, mais il s’agit de l’emplacement par défaut en cours de création.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Le chemin cible est l’emplacement par défaut ou vide, avec un préfixe avec « {0} »</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Aucun moniker de framework cible spécifié, à l’aide du premier moniker trouvé dans le projet.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Il percorso di destinazione '{0}' non esiste, ma è il percorso predefinito in fase di creazione.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Il percorso di destinazione è il percorso predefinito o vuoto, con prefisso '{0}'</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Non è stato specificato alcun moniker framework di destinazione. Verrà usato il primo moniker trovato nel progetto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">ターゲット パス '{0}' は存在しませんが、既定の場所が作成されています。</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">ターゲット パスは既定の場所または空で、プレフィックスは '{0}' です</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">ターゲット フレームワーク モニカーが指定されていません。プロジェクトで最初に見つかったモニカーを使用しています。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">'{0}' 대상 경로가 존재하지 않지만 기본 위치이므로 만듭니다.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">대상 경로가 기본 위치이거나 비어 있으며 '{0}'을(를) 접두사로 사용합니다.</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">대상 프레임워크 모니커가 지정되지 않았습니다. 프로젝트에서 찾는 첫 번째 모니커를 사용합니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Ścieżka docelowa „{0}” nie istnieje, ale jest lokalizacją domyślną, trwa tworzenie.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Ścieżka docelowa jest domyślną lokalizacją lub jest pusta. Prefiks ma wartość „{0}”</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Nie określono monikera platformy docelowej, używając pierwszego znalezionego w projekcie.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">O caminho de destino "{0}" não existe, mas é o local padrão, criando.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">O caminho de destino é o local padrão ou está vazio, com um prefixo "{0}"</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Nenhum moniker de estrutura de destino especificado, usando o primeiro encontrado no projeto.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Целевой путь "{0}" не существует, но является расположением по умолчанию, создается.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Целевой путь является расположением по умолчанию или пустым, с префиксом "{0}"</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Не указан моникер целевой платформы, используется первый найденный в проекте.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Hedef yolu '{0}' mevcut değil, ancak varsayılan konum oluşturuluyor.</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">Hedef yol varsayılan konumdur veya ön eki '{0}' olan boştur</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">Projede bulunan ilk çerçeve kullanılarak hedef çerçeve adı belirtilmedi.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">目标路径“{0}”不存在，但却是默认位置，正在创建。</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">目标路径是默认位置或为空，前缀为 "{0}"</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">未指定目标框架名字对象，正在使用在项目中找到的第一个。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">目標路徑 '{0}' 不存在，但它是預設位置，正在建立。</target>
         <note>{0} is the path to target project</note>
       </trans-unit>
+      <trans-unit id="Base.DotnetPath">
+        <source>Using the `dotnet` located at {0}.</source>
+        <target state="new">Using the `dotnet` located at {0}.</target>
+        <note>{0} is the path to dotnet</note>
+      </trans-unit>
       <trans-unit id="Base.EstablishDefaultTarget">
         <source>Target path is the default location or empty, prefixing with '{0}'</source>
         <target state="translated">目標路徑是預設位置或空白，前置詞為 '{0}'</target>
@@ -31,6 +36,11 @@
         <source>No target framework moniker specified, using the first one found in the project.</source>
         <target state="translated">未指定目標 Framework Moniker，正在使用在專案中找到的第一個目標 Framework Moniker。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="Base.XcodePath">
+        <source>Using Xcode from {0}.</source>
+        <target state="new">Using Xcode from {0}.</target>
+        <note>{0} is the path to Xcode</note>
       </trans-unit>
       <trans-unit id="Commands.Generate.Description">
         <source>generate a Xcode project at the path specified by --target from the project identified by --project</source>

--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -31,9 +31,9 @@ static class xcSync {
 	{
 		ConfigureLogging ();
 
-		RegisterMSBuild ();
-
 		WriteHeader ();
+
+		RegisterMSBuild ();
 
 		var parser = new CommandLineBuilder (new XcSyncCommand (FileSystem))
 			.UseDefaults ()

--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -20,6 +20,7 @@ namespace xcsync;
 static class xcSync {
 
 	public static string DotnetPath { get; set; } = string.Empty;
+	public static string XcodePath { get; set; } = string.Empty;
 
 	public static ApplePlatforms ApplePlatforms { get; } = new ();
 


### PR DESCRIPTION
Also fixed the dotnet path to be a localized string
Initializes the XcodePath during the base command validation, XcodeWorkspace uses the cached path.
Also ensures that the Header is displayed before any additional log messages
Move OS detection to BaseCommand Validator since XcSyncRootCommand Validation only runs when there is no command specified.


## Output
### base 
```
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.

[10:19:32 INF xcsync (1)] Using the `dotnet` located at .
Required command was not provided.

Description:
  xcsync

Usage:
  xcsync [command] [options]

Options:
  -v, --verbosity <Detailed|Diagnostic|Minimal|Normal|Quiet>  Set the verbosity level [default: Normal]
  -d, --dotnet-path <dotnet-path>                             Set the path to the .NET SDK, when not provided will use the path from the parent process if it is 'dotnet' otherwise falls back to the 'dotnet' on the PATH. []
  --version                                                   Show version information
  -?, -h, --help                                              Show help and usage information

Commands:
  generate  generate a Xcode project at the path specified by --target from the project identified by --project
  sync      synchronize changes from the Xcode project back to the.NET project
```
### generate
```
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.

[10:16:12 INF xcsync (1)] Using Xcode from /Applications/Xcode_15.4.0.app.
[10:16:12 INF xcsync (1)] Using the `dotnet` located at .
[10:16:12 INF xcsync (1)] Generating files from project 'test-project.csproj' to target 'obj/xcode'
[10:16:17 INF xcsync (16)] Generated Xcode project at 'obj/xcode'
```
### sync
```
xcSync v42.42.42.42, (c) Microsoft Corporation. All rights reserved.

[10:16:21 INF xcsync (1)] Using Xcode from /Applications/Xcode_15.4.0.app.
[10:16:21 INF xcsync (1)] Using the `dotnet` located at .
[10:16:21 INF xcsync (1)] Syncing files from project 'obj/xcode' to target 'test-project.csproj'
[10:16:24 INF xcsync (6)] Copied obj/xcode/Assets.xcassets to /Users/mcumming/repos/xcsync.worktrees/dev/mcumming/add-log-entry/test/test-project/Assets.xcassets
[10:16:24 INF xcsync (6)] Copied obj/xcode/Info.plist to /Users/mcumming/repos/xcsync.worktrees/dev/mcumming/add-log-entry/test/test-project/Info.plist
[10:16:24 INF xcsync (6)] Copied obj/xcode/Entitlements.plist to /Users/mcumming/repos/xcsync.worktrees/dev/mcumming/add-log-entry/test/test-project/Entitlements.plist
[10:16:24 INF xcsync (6)] Copied obj/xcode/Main.storyboard to /Users/mcumming/repos/xcsync.worktrees/dev/mcumming/add-log-entry/test/test-project/Main.storyboard

```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/145)