### PR TITLE
Get IntermediateOutputPath from csproj

### DIFF
--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -205,8 +205,12 @@ class BaseCommand<T> : Command {
 
 		targetPath = targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath);
 
+		if (string.IsNullOrEmpty(targetPath)) {
+			targetPath = fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder);
+		}
+
 		if (!fileSystem.Path.IsPathRooted (targetPath)) {
-			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
+			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath);
 		}
 
 		var xcodeProj = fileSystem.Path.Combine (targetPath, $"{fileSystem.Path.GetFileNameWithoutExtension (projectPath)}.xcodeproj");

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -209,19 +209,12 @@ class BaseCommand<T> : Command {
 			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
 		}
 
-		if (targetPath.EndsWith (fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder), StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty (targetPath)) {
-			LogVerbose (Strings.Base.EstablishDefaultTarget (fileSystem.Path.GetDirectoryName (projectPath)!));
+		var xcodeProj = fileSystem.Path.Combine (targetPath, $"{fileSystem.Path.GetFileNameWithoutExtension (projectPath)}.xcodeproj");
+		var pbxproj = fileSystem.Path.Combine (xcodeProj, "project.pbxproj");
 
-			if (!fileSystem.Directory.Exists (targetPath)) {
-				Console.WriteLine ($"<< creating {targetPath} >>");
-				LogDebug (Strings.Base.CreateDefaultTarget (targetPath));
-				fileSystem.Directory.CreateDirectory (targetPath);
-			}
-		}
-
-		if (!fileSystem.Directory.Exists (targetPath)) {
-			LogDebug (Strings.Errors.Validation.TargetDoesNotExist (targetPath));
-			error = Strings.Errors.Validation.TargetDoesNotExist (targetPath);
+		if (!fileSystem.Directory.Exists (targetPath) || !fileSystem.Directory.Exists (xcodeProj) || !fileSystem.File.Exists (pbxproj)) {
+			LogDebug (Strings.Errors.Validation.TargetIsNotValidXcodeProjectFolder (targetPath));
+			error = Strings.Errors.Validation.TargetIsNotValidXcodeProjectFolder (targetPath);
 			return (error, targetPath);
 		}
 

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -200,14 +200,20 @@ class BaseCommand<T> : Command {
 	protected virtual (string, string) TryValidateTargetPath (string projectPath, string tfm, string targetPath)
 	{
 		string error = string.Empty;
+
 		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (projectPath, tfm).Trim ();
-		LogVerbose ("IntermediateOuputPath = {IntermediateOutputPath}", intermediateOutputPath);
+
+		targetPath = targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath);
+
+		if (!fileSystem.Path.IsPathRooted (targetPath)) {
+			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
+		}
 
 		if (targetPath.EndsWith (fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder), StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty (targetPath)) {
 			LogVerbose (Strings.Base.EstablishDefaultTarget (fileSystem.Path.GetDirectoryName (projectPath)!));
-			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath) ?? ".", DefaultXcodeOutputFolder);
 
 			if (!fileSystem.Directory.Exists (targetPath)) {
+				Console.WriteLine ($"<< creating {targetPath} >>");
 				LogDebug (Strings.Base.CreateDefaultTarget (targetPath));
 				fileSystem.Directory.CreateDirectory (targetPath);
 			}

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -205,7 +205,7 @@ class BaseCommand<T> : Command {
 
 		targetPath = targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath);
 
-		if (string.IsNullOrEmpty(targetPath)) {
+		if (string.IsNullOrEmpty (targetPath)) {
 			targetPath = fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder);
 		}
 

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -12,7 +12,7 @@ using Serilog;
 namespace xcsync.Commands;
 
 class BaseCommand<T> : Command {
-	protected const string DefaultXcodeOutputFolder = "obj/xcode";
+	protected const string DefaultXcodeOutputFolder = "xcsync";
 	protected static ILogger? Logger { get; private set; }
 
 	/// <summary>
@@ -49,7 +49,7 @@ class BaseCommand<T> : Command {
 	protected Option<string> target = new (
 		["--target", "-t"],
 		description: Strings.Options.TargetDescription,
-		getDefaultValue: () => $".{Path.DirectorySeparatorChar}{DefaultXcodeOutputFolder}");
+		getDefaultValue: () => $"$(IntermediateOutputPath){Path.DirectorySeparatorChar}{DefaultXcodeOutputFolder}");
 
 	public BaseCommand (IFileSystem fileSystem, ILogger logger, string name, string description) : base (name, description)
 	{
@@ -103,10 +103,10 @@ class BaseCommand<T> : Command {
 		(error, string newProjectPath) = TryValidateProjectPath (projectPath);
 		if (!string.IsNullOrEmpty (error)) { return new ValidationResult (projectPath, moniker, targetPath, error); }
 
-		(error, string newTfm) = TryValidateTfm (projectPath, moniker);
+		(error, string newTfm) = TryValidateTfm (newProjectPath, moniker);
 		if (!string.IsNullOrEmpty (error)) { return new ValidationResult (newProjectPath, moniker, targetPath, error); }
 
-		(error, string newTargetPath) = TryValidateTargetPath (projectPath, targetPath);
+		(error, string newTargetPath) = TryValidateTargetPath (newProjectPath, newTfm, targetPath);
 		if (!string.IsNullOrEmpty (error)) { return new ValidationResult (newProjectPath, newTfm, targetPath, error); }
 
 		return new ValidationResult (newProjectPath, newTfm, newTargetPath, error);
@@ -197,11 +197,13 @@ class BaseCommand<T> : Command {
 		return (error, tfm);
 	}
 
-	protected virtual (string, string) TryValidateTargetPath (string projectPath, string targetPath)
+	protected virtual (string, string) TryValidateTargetPath (string projectPath, string tfm, string targetPath)
 	{
 		string error = string.Empty;
+		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (projectPath, tfm).Trim ();
+		LogVerbose ("IntermediateOuputPath = {IntermediateOutputPath}", intermediateOutputPath);
 
-		if (targetPath.EndsWith (DefaultXcodeOutputFolder, StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty (targetPath)) {
+		if (targetPath.EndsWith (fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder), StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty (targetPath)) {
 			LogVerbose (Strings.Base.EstablishDefaultTarget (fileSystem.Path.GetDirectoryName (projectPath)!));
 			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath) ?? ".", DefaultXcodeOutputFolder);
 

--- a/src/xcsync/Commands/XcodeCommand.cs
+++ b/src/xcsync/Commands/XcodeCommand.cs
@@ -45,9 +45,12 @@ class XcodeCommand<T> : BaseCommand<T> {
 	{
 		string error = string.Empty;
 		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (projectPath, tfm);
-		LogVerbose ("IntermediateOuputPath = {IntermediateOutputPath}", intermediateOutputPath);
 
-		targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
+		targetPath = targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath);
+
+		if (!fileSystem.Path.IsPathRooted (targetPath)) {
+			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
+		}
 
 		if (!Force) {
 			if (fileSystem.Directory.Exists (targetPath) && fileSystem.Directory.EnumerateFileSystemEntries (targetPath).Any ()) {

--- a/src/xcsync/Commands/XcodeCommand.cs
+++ b/src/xcsync/Commands/XcodeCommand.cs
@@ -41,14 +41,13 @@ class XcodeCommand<T> : BaseCommand<T> {
 		base.AddValidators ();
 	}
 
-	protected override (string, string) TryValidateTargetPath (string projectPath, string targetPath)
+	protected override (string, string) TryValidateTargetPath (string projectPath, string tfm, string targetPath)
 	{
 		string error = string.Empty;
+		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (projectPath, tfm);
+		LogVerbose ("IntermediateOuputPath = {IntermediateOutputPath}", intermediateOutputPath);
 
-		if (targetPath.EndsWith (DefaultXcodeOutputFolder, StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty (targetPath)) {
-			LogVerbose (Strings.Base.EstablishDefaultTarget (fileSystem.Path.GetDirectoryName (projectPath)!));
-			targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath) ?? ".", DefaultXcodeOutputFolder);
-		}
+		targetPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath)!, targetPath.Replace ("$(IntermediateOutputPath)", intermediateOutputPath));
 
 		if (!Force) {
 			if (fileSystem.Directory.Exists (targetPath) && fileSystem.Directory.EnumerateFileSystemEntries (targetPath).Any ()) {
@@ -56,7 +55,7 @@ class XcodeCommand<T> : BaseCommand<T> {
 				error = Strings.Errors.Validation.TargetNotEmpty (targetPath);
 			}
 
-			if (!fileSystem.Directory.Exists (targetPath) && string.Compare (targetPath, DefaultXcodeOutputFolder, StringComparison.OrdinalIgnoreCase) != 0) {
+			if (!fileSystem.Directory.Exists (targetPath) && !targetPath.EndsWith (fileSystem.Path.Combine (intermediateOutputPath, DefaultXcodeOutputFolder), StringComparison.OrdinalIgnoreCase)) {
 				LogDebug (Strings.Errors.Validation.TargetDoesNotExist (targetPath));
 				error = Strings.Errors.Validation.TargetDoesNotExist (targetPath);
 			}

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -74,7 +74,7 @@ partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeServi
 
 		var frameworkGroup = (from groups in Project.Objects.Values
 							  where groups.Isa == "PBXGroup" && groups is PBXGroup { Name: "Frameworks" }
-							  select groups as PBXGroup).First ().Children.AsQueryable ();
+							  select groups as PBXGroup).FirstOrDefault ()?.Children.AsQueryable () ?? Array.Empty<string> ().AsQueryable ();
 
 		var fileReferences = from fileRef in Project.Objects.Values
 							 where fileRef.Isa == "PBXFileReference"

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -31,6 +31,7 @@ static class Strings {
 			internal static string PathNameEmpty => Resources.Strings.Errors_Validation_PathNameIsEmpty;
 			internal static string PathDoesNotExist (string path) => string.Format (Resources.Strings.Errors_Validation_PathDoesNotExist, path);
 			internal static string TargetDoesNotExist (string path) => string.Format (Resources.Strings.Errors_Validation_TargetDoesNotExist, path);
+			internal static string TargetIsNotValidXcodeProjectFolder (string path) => string.Format (Resources.Strings.Errors_Validation_TargetIsNotValidXcodeProjectFolder, path);
 			internal static string TargetNotEmpty (string path) => string.Format (Resources.Strings.Errors_Validation_TargetIsNotEmpty, path);
 			internal static string PathDoesNotContainCsproj (string path) => string.Format (Resources.Strings.Errors_Validation_PathDoesNotContainCsproj, path);
 			internal static string MissingTfmInPath (string path) => string.Format (Resources.Strings.Errors_Validation_MissingValidTargetFrameworkInPath, path);

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -41,6 +41,7 @@ static class Strings {
 
 		internal static string InvalidOption (string option, string error) => string.Format (Resources.Strings.Errors_InvalidOption, option, error);
 		internal static string MultipleProjectFilesFound (string path, string projectFilesFound) => string.Format (Resources.Strings.Errors_MultipleProjectFilesFound, path, projectFilesFound);
+		internal static string PbxprojNotFound (string path) => string.Format (Resources.Strings.Errors_PbxprojNotFound, path);
 		internal static string CsprojNotFound (string path) => string.Format (Resources.Strings.Errors_CsprojNotFound, path);
 		internal static string MultipleTfmsFound => Resources.Strings.Errors_MultipleTfmsFound;
 		internal static string TargetPlatformNotFound => Resources.Strings.Errors_TargetPlatformNotFound;

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -168,6 +168,10 @@
 		<value>Invalid option '{0}' provided: {1}</value>
 		<comment>{0} is name of the command line options, {1} is the value of the option provided by the user</comment>
 	</data>
+	<data name="Errors.PbxprojNotFound" xml:space="preserve">
+		<value>Could not find a project.pbxproj file in path '{0}'</value>
+		<comment>{0} is the path to the file or directory</comment>
+	</data>
 	<data name="Errors.CsprojNotFound" xml:space="preserve">
 		<value>Could not find a .csproj file in path '{0}'</value>
 		<comment>{0} is the path to the file or directory</comment>

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -194,6 +194,10 @@
 		<value>Target path '{0}' does not exist, will create directory if [--force, -f] is set.</value>
 		<comment>{0} is the path to the file or directory</comment>
 	</data>
+	<data name="Errors.Validation.TargetIsNotValidXcodeProjectFolder" xml:space="preserve">
+		<value>Target path '{0}' does not exist, or is not a valid Xcode project folder.</value>
+		<comment>{0} is the path to the file or directory</comment>
+	</data>
 	<data name="Errors.Validation.PathDoesNotContainCsproj" xml:space="preserve">
 		<value>'{0}' is not a valid path to a .NET project or a directory.</value>
 		<comment>{0} is the path to the file or directory</comment>

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -77,6 +77,11 @@
         <target state="translated">V souboru projektu bylo nalezeno více cílových architektur. Pomocí možnosti [--target-framework, -tfm] zadejte cílovou architekturu, která se má použít.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Nebyla nalezena cílová platforma.</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Cílová cesta {0} už existuje a není prázdná. Pokud chcete přepsat existující projekt, použijte možnost [--force, -f].</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -77,6 +77,11 @@
         <target state="translated">In der Projektdatei wurden mehrere Zielframeworks gefunden. Geben Sie an, welches Zielframework mit der Option [--target-framework, -tfm] verwendet werden soll.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Zielplattform nicht gefunden</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Der Zielpfad "{0}" bereits vorhanden und ist nicht leer. Verwenden Sie [--force, -f], um das vorhandene Projekt zu überschreiben.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Se encontraron varias plataformas de destino en el archivo de proyecto. Especifique la plataforma de destino que se va a usar con la opción [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">No se encontró la plataforma de destino</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">La ruta de acceso de destino '{0}' ya existe y no está vacía. Use [--force, -f] para sobrescribir el proyecto existente.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Plusieurs frameworks cibles ont été trouvés dans le fichier projet. Spécifiez le framework cible à utiliser avec l’option [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Plateforme cible introuvable</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Le chemin cible « {0} » existe déjà et n’est pas vide. Utilisez [--force, -f] pour remplacer le projet existant.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Sono stati trovati più framework di destinazione nel file di progetto. Specificare il framework di destinazione da utilizzare con l'opzione [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Piattaforma di destinazione non trovata</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Il percorso di destinazione '{0}' esiste già e non è vuoto. Usare [--force, -f] per sovrascrivere il progetto esistente.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -77,6 +77,11 @@
         <target state="translated">プロジェクト ファイルに複数のターゲット フレームワークが見つかりました。[--target-framework, -tfm] オプションで使用するターゲット フレームワークを指定します。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">ターゲット プラットフォームが見つかりません</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">ターゲット パス '{0}' は既に存在し、空ではありません。既存のプロジェクトを上書きするには、[--force, -f] を使用します。</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -77,6 +77,11 @@
         <target state="translated">프로젝트 파일에 여러 대상 프레임워크가 있습니다. [--target-framework, -tfm] 옵션과 함께 사용할 대상 프레임워크를 지정합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">대상 플랫폼을 찾을 수 없음</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">'{0}' 대상 경로가 이미 있으며 비어 있지 않습니다. 기존 프로젝트를 덮어쓰려면 [--force, -f]를 사용하세요.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -77,6 +77,11 @@
         <target state="translated">W pliku projektu znaleziono wiele platform docelowych. Określ strukturę docelową, która ma być używana z opcją [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Nie znaleziono platformy docelowej</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Ścieżka docelowa „{0}” już istnieje i nie jest pusta. Użyj [--force, -f], aby zastąpić istniejący projekt.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Várias estruturas de destino encontradas no arquivo de projeto. Especifique qual estrutura de destino usar com a opção [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Plataforma de destino não encontrada</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">O caminho de destino "{0}" já existe e não está vazio. Use [--force, -f] para substituir o projeto existente.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -77,6 +77,11 @@
         <target state="translated">В файле проекта найдено несколько целевых платформ. Укажите целевую платформу для использования с параметром [--target-framework, -tfm].</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Целевая платформа не найдена</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">Целевой путь "{0}" уже существует и не пуст. Используйте [--force, -f] для перезаписи существующего проекта.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -77,6 +77,11 @@
         <target state="translated">Proje dosyasında birden fazla hedef çerçeve bulundu. [--target-framework, -tfm] seçeneğiyle hangi hedef çerçevenin kullanılacağını belirtin.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">Hedef platform bulunamadı</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">'{0}' hedef yolu zaten mevcut ve boş değil. Mevcut projenin üzerine yazmak için [--force, -f] kullanın.</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -77,6 +77,11 @@
         <target state="translated">在项目文件中找到多个目标框架。通过 [--target-framework, -tfm] 选项指定要使用的目标框架。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">找不到目标平台</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">目标路径“{0}”已存在且不为空。使用 [--force, -f] 覆盖现有项目。</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -77,6 +77,11 @@
         <target state="translated">在專案檔案中發現多個目標 Framework。指定要搭配 [--target-framework, -tfm] 選項使用的目標 Framework。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Errors.PbxprojNotFound">
+        <source>Could not find a project.pbxproj file in path '{0}'</source>
+        <target state="new">Could not find a project.pbxproj file in path '{0}'</target>
+        <note>{0} is the path to the file or directory</note>
+      </trans-unit>
       <trans-unit id="Errors.TargetPlatformNotFound">
         <source>Target platform not found</source>
         <target state="translated">找不到目標平台</target>
@@ -131,6 +136,11 @@
         <source>The target path '{0}' already exists and is not empty. Use [--force, -f] to overwrite the existing project.</source>
         <target state="translated">目標路徑 '{0}' 已存在且不是空白。使用 [--force, -f] 來覆寫現有的專案。</target>
         <note>{0} is the path to the directory</note>
+      </trans-unit>
+      <trans-unit id="Errors.Validation.TargetIsNotValidXcodeProjectFolder">
+        <source>Target path '{0}' does not exist, or is not a valid Xcode project folder.</source>
+        <target state="new">Target path '{0}' does not exist, or is not a valid Xcode project folder.</target>
+        <note>{0} is the path to the file or directory</note>
       </trans-unit>
       <trans-unit id="Generate.GeneratedFiles">
         <source>Generated Xcode header and implementation files</source>

--- a/src/xcsync/Scripts.cs
+++ b/src/xcsync/Scripts.cs
@@ -186,6 +186,17 @@ static class Scripts {
 		return Path.GetFullPath ($"{exec.StandardOutput?.ToString ()?.Trim ('\n')}/../..");
 	}
 
+	public static string GetIntermediateOutputPath (string projPath, string tfm)
+	{
+		const string IntermediateOutputPath = nameof (IntermediateOutputPath);
+		var resultFile = Path.GetTempFileName ();
+		var args = new [] { "msbuild", projPath, $"-property:TargetFramework={tfm}", $"-getProperty:{IntermediateOutputPath}", $"-getResultOutputFile:{resultFile}" };
+		ExecuteCommand (PathToDotnet, args, TimeSpan.FromMinutes (1));
+
+		var result = File.ReadAllText (resultFile).TrimEnd ('/', '\\', '\n').Replace ('\\', Path.DirectorySeparatorChar);
+
+		return result ?? string.Empty;
+	}
 #pragma warning restore IO0006 // Replace Path class with IFileSystem.Path for improved testability
 #pragma warning restore IO0002 // Replace File class with IFileSystem.File for improved testability
 

--- a/src/xcsync/Scripts.cs
+++ b/src/xcsync/Scripts.cs
@@ -80,7 +80,7 @@ static class Scripts {
 		ExecuteCommand (PathToDotnet, args, TimeSpan.FromMinutes (1));
 
 		var result = File.ReadAllText (resultFile).Trim ('\n');
-		
+
 		SafeFileDelete (resultFile);
 
 		return result;
@@ -214,7 +214,8 @@ static class Scripts {
 		return result ?? string.Empty;
 	}
 
-	static void SafeFileDelete (string file) {
+	static void SafeFileDelete (string file)
+	{
 		try {
 			File.Delete (file);
 		} catch (Exception ex) {

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
-using System.Runtime.Versioning;
 using Marille;
 using Microsoft.CodeAnalysis;
 using Serilog;
@@ -54,6 +53,10 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		if (force && FileSystem.Directory.Exists (projectFilesPath)) {
 			// remove existing xcode project
 			FileSystem.Directory.Delete (projectFilesPath, true);
+		}
+
+		if (!FileSystem.Directory.Exists (TargetDir)) {
+			FileSystem.Directory.CreateDirectory (TargetDir);
 		}
 
 		HashSet<string> frameworks = ["Foundation", "Cocoa"];

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -473,16 +473,15 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		var dotNetProject = new ClrProject (FileSystem, Logger, TypeService, projectName, ProjectPath, Framework.ToString ());
 		await dotNetProject.OpenProject ().ConfigureAwait (false);
 
+		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
 
 		var xcodeproj = FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj");
 		var pbxProjPath = FileSystem.Path.Combine (xcodeproj, "project.pbxproj");
 		if (!FileSystem.File.Exists (pbxProjPath)) {
-			LogFatal (Strings.SyncContext.PbxprojNotFound (xcodeproj));
+			Logger.Fatal (Strings.Errors.PbxprojNotFound (xcodeproj));
 			return;
 		}
 		Scripts.ConvertPbxProjToJson (pbxProjPath);
-
-		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
 
 		await xcodeWorkspace.LoadAsync (token).ConfigureAwait (false);
 

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -476,9 +476,8 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 
 		var xcodeproj = FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj");
 		var pbxProjPath = FileSystem.Path.Combine (xcodeproj, "project.pbxproj");
-		if (!FileSystem.File.Exists(pbxProjPath)) 
-		{
-			LogFatal(Strings.SyncContext.PbxprojNotFound(xcodeproj));
+		if (!FileSystem.File.Exists (pbxProjPath)) {
+			LogFatal (Strings.SyncContext.PbxprojNotFound (xcodeproj));
 			return;
 		}
 		Scripts.ConvertPbxProjToJson (pbxProjPath);

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -473,9 +473,17 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		var dotNetProject = new ClrProject (FileSystem, Logger, TypeService, projectName, ProjectPath, Framework.ToString ());
 		await dotNetProject.OpenProject ().ConfigureAwait (false);
 
-		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
 
-		Scripts.ConvertPbxProjToJson (FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj", "project.pbxproj"));
+		var xcodeproj = FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj");
+		var pbxProjPath = FileSystem.Path.Combine (xcodeproj, "project.pbxproj");
+		if (!FileSystem.File.Exists(pbxProjPath)) 
+		{
+			LogFatal(Strings.SyncContext.PbxprojNotFound(xcodeproj));
+			return;
+		}
+		Scripts.ConvertPbxProjToJson (pbxProjPath);
+
+		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
 
 		await xcodeWorkspace.LoadAsync (token).ConfigureAwait (false);
 

--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -28,7 +28,7 @@ static class xcSync {
 	public static ILogger? Logger { get; internal set; }
 	public static IFileSystem FileSystem { get; } = new FileSystem ();
 
-	public static async Task Main (string [] args)
+	public static async Task<int> Main (string [] args)
 	{
 		ConfigureLogging ();
 
@@ -40,7 +40,7 @@ static class xcSync {
 			.UseDefaults ()
 			.Build ();
 
-		await parser.InvokeAsync (args).ConfigureAwait (false);
+		return await parser.InvokeAsync (args).ConfigureAwait (false);
 	}
 
 	static void RegisterMSBuild ()

--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -57,6 +57,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="xcsync.tests" />
+    <InternalsVisibleTo Include="xcsync.e2e.tests" />
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" /> <!-- Needed for Moq -->
   </ItemGroup>
 

--- a/test/xcsync.e2e.tests/usecases/GenerateTargetPathArgumentTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateTargetPathArgumentTests.cs
@@ -1,0 +1,224 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xamarin;
+using Xunit.Abstractions;
+
+namespace xcsync.e2e.tests.UseCases;
+
+public partial class GenerateTargetPathArgumentTests :
+	Base,
+	IClassFixture<GenerateTargetPathArgumentTests.TargetPathTestsFixture>,
+	IDisposable {
+	string targetPath = string.Empty;
+	readonly TargetPathTestsFixture fixture;
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 1, false)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 1, false)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderDoesNotExist (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => { }
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderExistsAndIsEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => {
+				Directory.CreateDirectory (path);
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 1, true)]
+	[InlineData ("artifacts/xcsync", 1, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 1, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 1, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderExistsAndIsNotEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => {
+				Directory.CreateDirectory (path);
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderDoesNotExist (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => { }
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderExistsAndIsEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => {
+				Directory.CreateDirectory (path);
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderExistsAndIsNotEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => {
+				Directory.CreateDirectory (path);
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+			}
+		);
+	}
+
+	public class TargetPathTestsFixture : IDisposable {
+		public string RootPath { get; private set; } = string.Empty;
+		public string IntermediateOutputPath { get; private set; } = string.Empty;
+		public string [] Args { get; set; } = [];
+
+		public void Dispose ()
+		{
+			// Cleanup
+			GC.SuppressFinalize (this);
+		}
+
+		public async Task InitAsync (ITestOutputHelper TestOutput)
+		{
+			if (RootPath != string.Empty) return;
+
+			var projectName = Guid.NewGuid ().ToString ();
+			var projectType = "macos";
+			var tfm = "net8.0-macos";
+			RootPath = Cache.CreateTemporaryDirectory (projectName);
+
+			var csproj = Path.Combine (RootPath, $"{projectName}.csproj");
+
+			await DotnetNew (TestOutput, projectType, RootPath, string.Empty).ConfigureAwait (false);
+
+			IntermediateOutputPath = Scripts.GetIntermediateOutputPath (csproj, tfm);
+
+			Args = [
+				"generate",
+				"--project",
+				csproj,
+				"-tfm",
+				tfm,
+				"--verbosity",
+				"diagnostic"
+			];
+		}
+	}
+
+	async Task TargetPath_BaseTest (string targetPath, int expectedExitCode, bool expectedDirectortyExists, Func<string []> getAdditionalCommandLineArgs, Action<string> arrangeTargetPathFolder)
+	{
+		// Arrange
+		var cacheRoot = Cache.GetRoot ();
+		var intermediateOutputPath = fixture.IntermediateOutputPath;
+		var rootedTargetPath = targetPath
+			.Replace ("{IntermediateOutputPath}", intermediateOutputPath)
+			.Replace ("{CacheRoot}", cacheRoot);
+
+		this.targetPath = rootedTargetPath;
+		var args = fixture.Args;
+
+		if (rootedTargetPath != string.Empty)
+			args = [.. args, "--target", rootedTargetPath];
+
+		if (rootedTargetPath == string.Empty)
+			rootedTargetPath = Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath, "xcsync");
+		else
+			rootedTargetPath = Path.Combine (fixture.RootPath, rootedTargetPath);
+
+		args = [.. args, .. getAdditionalCommandLineArgs ()];
+
+		arrangeTargetPathFolder (rootedTargetPath);
+
+		// Act		
+		var exitCode = await Xcsync (TestOutput, args).ConfigureAwait (false);
+
+		// Assert
+		Assert.Equal (expectedExitCode, exitCode);
+		Assert.Equal (expectedDirectortyExists, Directory.Exists (rootedTargetPath));
+	}
+
+	public GenerateTargetPathArgumentTests (ITestOutputHelper testOutput, TargetPathTestsFixture fixture) : base (testOutput)
+	{
+		this.fixture = fixture;
+		this.fixture.InitAsync (testOutput).Wait ();
+	}
+
+	public void Dispose ()
+	{
+		// Cleanup
+		SafeDirectoryDelete (Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath));
+		var rootedTarget = targetPath;
+		if (!Path.IsPathRooted (targetPath)) {
+			var targetRoot = Path.GetDirectoryName (targetPath)?.Split (Path.DirectorySeparatorChar) [0];
+			if (targetRoot != null) {
+				rootedTarget = Path.Combine (fixture.RootPath, targetRoot);
+			}
+		}
+		SafeDirectoryDelete (rootedTarget);
+		GC.SuppressFinalize (this);
+	}
+
+	void SafeDirectoryDelete (string root)
+	{
+		if (Directory.Exists (root)) {
+			TestOutput.WriteLine ($">> Deleting {root}");
+			var movedRoot = root + DateTime.UtcNow.Ticks.ToString () + "-deletion-in-progress";
+			// The temporary directory can be big, and it can take a while to clean it out.
+			// So move it to a different name (which should be fast), and then do the deletion on a different thread.
+			// This should speed up startup in some cases.
+			if (!Directory.Exists (movedRoot)) {
+				try {
+					Directory.Move (root, movedRoot);
+					ThreadPool.QueueUserWorkItem ((v) => {
+						try { Directory.Delete (movedRoot, true); } catch { }
+					});
+				} catch {
+					// Just delete the root if we can't move the temporary directory.
+					Directory.Delete (root, true);
+				}
+			} else {
+				Directory.Delete (root, true);
+			}
+		}
+	}
+}

--- a/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithChangesTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithChangesTests.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.IO.Abstractions;
 using Xamarin;
 using Xunit.Abstractions;
 
@@ -42,7 +41,7 @@ public partial class GenerateThenSyncWithChangesTests (ITestOutputHelper testOut
 
 		var tmpDir = Cache.CreateTemporaryDirectory (projectName);
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 
 		Directory.CreateDirectory (xcodeDir);
 
@@ -85,7 +84,7 @@ public partial class GenerateThenSyncWithChangesTests (ITestOutputHelper testOut
 
 		var tmpDir = Cache.CreateTemporaryDirectory (projectName);
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 
 		Directory.CreateDirectory (xcodeDir);
 

--- a/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
+++ b/test/xcsync.e2e.tests/usecases/GenerateThenSyncWithNoChangesTests.cs
@@ -25,7 +25,7 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 
 		var tmpDir = Cache.CreateTemporaryDirectory (projectName);
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 
 		Directory.CreateDirectory (xcodeDir);
 
@@ -70,7 +70,7 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 
 		var tmpDir = Cache.CreateTemporaryDirectory (projectName);
 
-		var xcodeDir = Path.Combine ("obj", "xcode");
+		var xcodeDir = Path.Combine ("obj", "xcsync");
 
 		Directory.CreateDirectory (Path.Combine (tmpDir, xcodeDir));
 
@@ -124,7 +124,7 @@ public partial class GenerateThenSyncWithNoChangesTests (ITestOutputHelper testO
 			var csproj = Path.Combine (repoRootDir, projectRelativePath);
 			var csprojDir = Path.GetDirectoryName (csproj) ?? repoRootDir;
 
-			var xcodeDir = Path.Combine (csprojDir, "obj", "xcode");
+			var xcodeDir = Path.Combine (csprojDir, "obj", "xcsync");
 			Directory.CreateDirectory (xcodeDir);
 
 			await DotnetNew (TestOutput, "gitignore", csprojDir, string.Empty).ConfigureAwait (false);

--- a/test/xcsync.e2e.tests/usecases/SyncTargetPathArgumentTests.cs
+++ b/test/xcsync.e2e.tests/usecases/SyncTargetPathArgumentTests.cs
@@ -168,15 +168,15 @@ public partial class SyncTargetPathArgumentTests :
 	public void Dispose ()
 	{
 		// Cleanup
-		// SafeDirectoryDelete (Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath));
-		// var rootedTarget = targetPath;
-		// if (!Path.IsPathRooted (targetPath)) {
-		// 	var targetRoot = Path.GetDirectoryName (targetPath)?.Split (Path.DirectorySeparatorChar) [0];
-		// 	if (targetRoot != null) {
-		// 		rootedTarget = Path.Combine (fixture.RootPath, targetRoot);
-		// 	}
-		// }
-		// SafeDirectoryDelete (rootedTarget);
+		SafeDirectoryDelete (Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath));
+		var rootedTarget = targetPath;
+		if (!Path.IsPathRooted (targetPath)) {
+			var targetRoot = Path.GetDirectoryName (targetPath)?.Split (Path.DirectorySeparatorChar) [0];
+			if (targetRoot != null) {
+				rootedTarget = Path.Combine (fixture.RootPath, targetRoot);
+			}
+		}
+		SafeDirectoryDelete (rootedTarget);
 
 		GC.SuppressFinalize (this);
 	}

--- a/test/xcsync.e2e.tests/usecases/SyncTargetPathArgumentTests.cs
+++ b/test/xcsync.e2e.tests/usecases/SyncTargetPathArgumentTests.cs
@@ -66,7 +66,7 @@ public partial class SyncTargetPathArgumentTests :
 			() => [],
 			(path) => {
 				Directory.CreateDirectory (path);
-				Directory.CreateDirectory (Path.Combine (path, $"{Path.GetFileName(fixture.RootPath)!}.xcodeproj"));
+				Directory.CreateDirectory (Path.Combine (path, $"{Path.GetFileName (fixture.RootPath)!}.xcodeproj"));
 				File.WriteAllTextAsync (Path.Combine (path, $"{Path.GetFileName (fixture.RootPath)!}.xcodeproj", "project.pbxproj"), pbxprojContent).Wait ();
 			}
 		);
@@ -84,7 +84,7 @@ public partial class SyncTargetPathArgumentTests :
 			() => [],
 			(path) => {
 				Directory.CreateDirectory (path);
-				File.WriteAllTextAsync (Path.Combine (path, "file.txt"), "content").Wait (); 
+				File.WriteAllTextAsync (Path.Combine (path, "file.txt"), "content").Wait ();
 			}
 		);
 	}

--- a/test/xcsync.e2e.tests/usecases/TargetPathTests.cs
+++ b/test/xcsync.e2e.tests/usecases/TargetPathTests.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Xamarin;
+using Xunit.Abstractions;
+
+namespace xcsync.e2e.tests.UseCases;
+
+public partial class TargetPathTests :
+	Base,
+	IClassFixture<TargetPathTests.TargetPathTestsFixture>,
+	IDisposable {
+	string targetPath = string.Empty;
+	readonly TargetPathTestsFixture fixture;
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 1, false)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 1, false)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderDoesNotExist (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => { }
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderExistsAndIsEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => {
+				Directory.CreateDirectory (path);
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 1, true)]
+	[InlineData ("artifacts/xcsync", 1, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 1, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 1, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_NoForceAndFolderExistsAndIsNotEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => [],
+			(path) => {
+				Directory.CreateDirectory (path);
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderDoesNotExist (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => { }
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderExistsAndIsEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => {
+				Directory.CreateDirectory (path);
+			}
+		);
+	}
+
+	[Theory]
+	[InlineData ("", 0, true)]
+	[InlineData ("artifacts/xcsync", 0, true)]
+	[InlineData ("{IntermediateOutputPath}/xcsync", 0, true)]
+	[InlineData ("{CacheRoot}/artifacts/xcsync", 0, true)]
+	[Trait ("Category", "IntegrationTest")]
+	public async Task TargetPath_WithForceAndFolderExistsAndIsNotEmpty (string targetPath, int expectedExitCode, bool expectedDirectortyExists)
+	{
+		await TargetPath_BaseTest (targetPath, expectedExitCode, expectedDirectortyExists,
+			() => ["--force"],
+			(path) => {
+				Directory.CreateDirectory (path);
+				File.WriteAllText (Path.Combine (path, "file.txt"), "content");
+			}
+		);
+	}
+
+	public class TargetPathTestsFixture : IDisposable {
+		public string RootPath { get; private set; } = string.Empty;
+		public string IntermediateOutputPath { get; private set; } = string.Empty;
+		public string [] Args { get; set; } = [];
+
+		public void Dispose ()
+		{
+			// Cleanup
+			GC.SuppressFinalize (this);
+		}
+
+		public async Task InitAsync (ITestOutputHelper TestOutput)
+		{
+			if (RootPath != string.Empty) return;
+
+			var projectName = Guid.NewGuid ().ToString ();
+			var projectType = "macos";
+			var tfm = "net8.0-macos";
+			RootPath = Cache.CreateTemporaryDirectory (projectName);
+
+			var csproj = Path.Combine (RootPath, $"{projectName}.csproj");
+
+			await DotnetNew (TestOutput, projectType, RootPath, string.Empty).ConfigureAwait (false);
+
+			IntermediateOutputPath = Scripts.GetIntermediateOutputPath (csproj, tfm);
+
+			Args = [
+				"generate",
+				"--project",
+				csproj,
+				"-tfm",
+				tfm,
+				"--verbosity",
+				"diagnostic"
+			];
+		}
+	}
+
+	async Task TargetPath_BaseTest (string targetPath, int expectedExitCode, bool expectedDirectortyExists, Func<string []> getAdditionalCommandLineArgs, Action<string> arrangeTargetPathFolder)
+	{
+		// Arrange
+		var cacheRoot = Cache.GetRoot ();
+		var intermediateOutputPath = fixture.IntermediateOutputPath;
+		var rootedTargetPath = targetPath
+			.Replace ("{IntermediateOutputPath}", intermediateOutputPath)
+			.Replace ("{CacheRoot}", cacheRoot);
+
+		this.targetPath = rootedTargetPath;
+		var args = fixture.Args;
+
+		if (rootedTargetPath != string.Empty)
+			args = [.. args, "--target", rootedTargetPath];
+
+		if (rootedTargetPath == string.Empty)
+			rootedTargetPath = Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath, "xcsync");
+		else
+			rootedTargetPath = Path.Combine (fixture.RootPath, rootedTargetPath);
+
+		args = [.. args, .. getAdditionalCommandLineArgs ()];
+
+		arrangeTargetPathFolder (rootedTargetPath);
+
+		// Act		
+		var exitCode = await Xcsync (TestOutput, args).ConfigureAwait (false);
+
+		// Assert
+		Assert.Equal (expectedExitCode, exitCode);
+		Assert.Equal (expectedDirectortyExists, Directory.Exists (rootedTargetPath));
+	}
+
+	public TargetPathTests (ITestOutputHelper testOutput, TargetPathTests.TargetPathTestsFixture fixture) : base (testOutput)
+	{
+		this.fixture = fixture;
+		this.fixture.InitAsync (testOutput).Wait ();
+	}
+
+	public void Dispose ()
+	{
+		// Cleanup
+		SafeDirectoryDelete (Path.Combine (fixture.RootPath, fixture.IntermediateOutputPath));
+		if (Path.IsPathRooted (targetPath)) {
+			SafeDirectoryDelete (targetPath);
+		} else {
+			var targetRoot = Path.GetDirectoryName (targetPath)?.Split (Path.DirectorySeparatorChar) [0];
+			if (targetRoot != null) {
+				var rootedTarget = Path.Combine (fixture.RootPath, targetRoot);
+				SafeDirectoryDelete (rootedTarget);
+			}
+		}
+
+		GC.SuppressFinalize (this);
+	}
+
+	void SafeDirectoryDelete (string root)
+	{
+		if (Directory.Exists (root)) {
+			TestOutput.WriteLine ($">> Deleting {root}");
+			var movedRoot = root + DateTime.UtcNow.Ticks.ToString () + "-deletion-in-progress";
+			// The temporary directory can be big, and it can take a while to clean it out.
+			// So move it to a different name (which should be fast), and then do the deletion on a different thread.
+			// This should speed up startup in some cases.
+			if (!Directory.Exists (movedRoot)) {
+				try {
+					Directory.Move (root, movedRoot);
+					ThreadPool.QueueUserWorkItem ((v) => {
+						Directory.Delete (movedRoot, true);
+					});
+				} catch {
+					// Just delete the root if we can't move the temporary directory.
+					Directory.Delete (root, true);
+				}
+			} else {
+				Directory.Delete (root, true);
+			}
+		}
+	}
+}

--- a/test/xcsync.tests/Commands/CommandValidationTests.cs
+++ b/test/xcsync.tests/Commands/CommandValidationTests.cs
@@ -88,8 +88,8 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		var fullProjectPath = Path.Combine (tmpDir, $"{projectName}.csproj");
 
 		var projectTfm = Scripts.GetTargetFrameworksFromProject (fullProjectPath).FirstOrDefault () ?? string.Empty;
-		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (fullProjectPath, string.IsNullOrEmpty(tfm) ? projectTfm : tfm);
-		
+		var intermediateOutputPath = Scripts.GetIntermediateOutputPath (fullProjectPath, string.IsNullOrEmpty (tfm) ? projectTfm : tfm);
+
 		targetPath = targetPath
 			.Replace ("{DoesNotExist}", string.Empty)
 			.Replace ("{IntermediateOutputPath}", intermediateOutputPath)
@@ -312,7 +312,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		Assert.Equal ("", errorMessage);
 	}
 
-	private static void EnsureXcodeProject (FileSystem fileSystem, string projectName, string xcodePath)
+	static void EnsureXcodeProject (FileSystem fileSystem, string projectName, string xcodePath)
 	{
 		var pbxprojContent = @"
 // !$*UTF8*$!
@@ -327,7 +327,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 ";
 		fileSystem.Directory.CreateDirectory (xcodePath);
 		fileSystem.Directory.CreateDirectory (Path.Combine (xcodePath, $"{projectName}.xcodeproj"));
-		fileSystem.File.WriteAllTextAsync (Path.Combine (xcodePath, $"{projectName}.xcodeproj", "project.pbxproj"), pbxprojContent ).Wait ();
+		fileSystem.File.WriteAllTextAsync (Path.Combine (xcodePath, $"{projectName}.xcodeproj", "project.pbxproj"), pbxprojContent).Wait ();
 	}
 
 	const string net_8_0_iosProject = @"

--- a/test/xcsync.tests/Projects/XcodeProjectTest.cs
+++ b/test/xcsync.tests/Projects/XcodeProjectTest.cs
@@ -354,7 +354,7 @@ public class XcodeProjectTest (ITestOutputHelper TestOutput) : Base {
 
 		Assert.True (Directory.Exists (tmpDir));
 
-		var xcodeDir = Path.Combine (tmpDir, "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "xcsync");
 		Directory.CreateDirectory (xcodeDir); // create directory so --Force is not needed
 
 		var csproj = Path.Combine (tmpDir, $"{projectName}.csproj");
@@ -388,7 +388,7 @@ public class XcodeProjectTest (ITestOutputHelper TestOutput) : Base {
 
 		Assert.True (Directory.Exists (Path.Combine (tmpDir)));
 
-		var xcodeDir = Path.Combine (tmpDir, "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "xcsync");
 		Directory.CreateDirectory (xcodeDir);
 		var csproj = Path.Combine (tmpDir, $"{projectName}.csproj");
 		string projectPath = Path.Combine (xcodeDir, $"{Path.GetFileName (projectName)}.xcodeproj");

--- a/test/xcsync.tests/Projects/XcodeWorkspaceTests.cs
+++ b/test/xcsync.tests/Projects/XcodeWorkspaceTests.cs
@@ -42,7 +42,7 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 		await DotnetNew (TestOutput, projectType, tmpDir, string.Empty);
 		var newProject = projectType;
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 		Directory.CreateDirectory (xcodeDir);
 
 		var csproj = Path.Combine (tmpDir, $"{projectName}.csproj");
@@ -86,7 +86,7 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 
 		await DotnetNew (TestOutput, projectType, tmpDir, string.Empty);
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 		Directory.CreateDirectory (xcodeDir);
 
 		var csproj = Path.Combine (tmpDir, $"{projectName}.csproj");
@@ -157,7 +157,7 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 
 		await DotnetNew (TestOutput, projectType, tmpDir, string.Empty);
 
-		var xcodeDir = Path.Combine (tmpDir, "obj", "xcode");
+		var xcodeDir = Path.Combine (tmpDir, "obj", "xcsync");
 		Directory.CreateDirectory (xcodeDir);
 
 		var csproj = Path.Combine (tmpDir, $"{projectName}.csproj");
@@ -177,7 +177,7 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 		var pbxProjFileData = await File.ReadAllTextAsync (pbjProjFile);
 		var fileSystem = new MockFileSystem ();
 		var projectName = Guid.NewGuid ().ToString ();
-		var xcodeDir = Path.Combine ("obj", "xcode");
+		var xcodeDir = Path.Combine ("obj", "xcsync");
 
 		var projectPath = Path.Combine (xcodeDir, $"{projectName}.xcodeproj");
 
@@ -202,7 +202,7 @@ public partial class XcodeWorkspaceTests (ITestOutputHelper TestOutput) : Base {
 		var logger = new Mock<ILogger> ();
 
 		var projectName = Guid.NewGuid ().ToString ();
-		var xcodeDir = Path.Combine ("obj", "xcode");
+		var xcodeDir = Path.Combine ("obj", "xcsync");
 
 		var pbxProjFile = Path.Combine (xcodeDir, $"{projectName}.xcodeproj", "project.pbxproj");
 


### PR DESCRIPTION
This change will use the `$(IntermediateOutputPath)` from the evaluated target csproj to determine the location of the TargetPath if no [`-t`, `--TargetPath`] argument is provided.

This change does cause the output to display the full path to the csproj and output folders now instead of relative paths.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/154)