### PR TITLE
Use GetAssetItemsFromProject for all project types

### DIFF
--- a/src/xcsync/Scripts.cs
+++ b/src/xcsync/Scripts.cs
@@ -115,7 +115,7 @@ static class Scripts {
 	{
 		var resultFile = Path.GetTempFileName ();
 		//maybe add support for ImageAsset? But right now doesn't seem v necessary? (Default is BundleResource)
-		var args = new [] { "msbuild", projPath, "-getItem:BundleResource", $"-property:TargetFramework={tfm}", $"-getResultOutputFile:{resultFile}" };
+		var args = new [] { "msbuild", projPath, "-getItem:BundleResource,ImageAsset", $"-property:TargetFramework={tfm}", $"-getResultOutputFile:{resultFile}" };
 		ExecuteCommand (PathToDotnet, args, TimeSpan.FromMinutes (1));
 
 		// dynamic cuz don't wanna create a whole class to rep the incoming json

--- a/src/xcsync/Scripts.cs
+++ b/src/xcsync/Scripts.cs
@@ -120,26 +120,33 @@ static class Scripts {
 
 		// dynamic cuz don't wanna create a whole class to rep the incoming json
 		dynamic data = JsonConvert.DeserializeObject (File.ReadAllText (resultFile))!;
-		var bundleResources = data.Items.BundleResource;
-		HashSet<string> assetPaths = new ();
 
-		// iterate through bundle resources , specific to tfm, and compute the appropriate asset paths
-		foreach (var item in bundleResources) {
-			var id = item.Identity.ToString ().Replace ('\\', '/');
-			if (id.Contains ("Assets.xcassets")) {
-				if (!Path.IsPathRooted (id))
-					// Combine with the project path if it's not a full path
-					id = Path.Combine (Path.GetDirectoryName (projPath), id);
+		HashSet<string> assetPaths = [];
 
-				// Strip off anything after ".xcassets"
-				var index = id.IndexOf (".xcassets", StringComparison.Ordinal);
-				if (index > -1)
-					id = id.Substring (0, index + ".xcassets".Length);
+		GetAssetPaths (projPath, data.Items.BundleResource, assetPaths);
+		GetAssetPaths (projPath, data.Items.ImageAsset, assetPaths);
 
-				assetPaths.Add (id);
+		return assetPaths;
+
+		static void GetAssetPaths (string projPath, dynamic bundleResources, HashSet<string> assetPaths)
+		{
+			// iterate through bundle resources , specific to tfm, and compute the appropriate asset paths
+			foreach (var item in bundleResources) {
+				var id = item.Identity.ToString ().Replace ('\\', '/');
+				if (id.Contains ("Assets.xcassets")) {
+					if (!Path.IsPathRooted (id))
+						// Combine with the project path if it's not a full path
+						id = Path.Combine (Path.GetDirectoryName (projPath), id);
+
+					// Strip off anything after ".xcassets"
+					var index = id.IndexOf (".xcassets", StringComparison.Ordinal);
+					if (index > -1)
+						id = id.Substring (0, index + ".xcassets".Length);
+
+					assetPaths.Add (id);
+				}
 			}
 		}
-		return assetPaths;
 	}
 
 	public static List<string> GetFileItemsFromProject (string projPath, string tfm, string targetPlatform)

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -216,15 +216,6 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		// copy assets
-		// single plat project support
-		var assetsFolder = FileSystem.Directory
-			.EnumerateDirectories (appleDirectory, "*.xcassets", SearchOption.TopDirectoryOnly).FirstOrDefault (); //TODO: add support for multiple asset folders
-		if (assetsFolder is not null) {
-			Scripts.CopyDirectory (FileSystem, assetsFolder, FileSystem.Path.Combine (TargetDir, FileSystem.Path.GetFileName (assetsFolder)), true);
-			AddAsset (assetsFolder);
-		}
-
-		// maui support
 		foreach (var asset in Scripts.GetAssetItemsFromProject (ProjectPath, Framework.ToString ())) {
 			Scripts.CopyDirectory (FileSystem, asset, FileSystem.Path.Combine (TargetDir, "Assets.xcassets"), true);
 			AddAsset (asset);


### PR DESCRIPTION
Slight refactoring to use the GetAssetItemsFromProject for all project types and not just .NET MAUI projects. This unifies how we determine which files should be part of the generated project.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/161)