### PR TITLE
fix duplicate register attribute during sync scenario

### DIFF
--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -113,11 +113,6 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 				.WithTrailingTrivia (trailingTrivia)
 				// .AddModifiers (Token (SyntaxKind.PublicKeyword))
 				.AddModifiers (Token (SyntaxKind.PartialKeyword))
-							.AddAttributeLists (
-				AttributeList (SingletonSeparatedList (
-					Attribute (IdentifierName ("Register"),
-						AttributeArgumentList (SingletonSeparatedList (
-							AttributeArgument (LiteralExpression (SyntaxKind.StringLiteralExpression, Literal (objcImpl.Name)))))))))
 				.AddMembers (releaseDesignerOutletsMethod);
 
 			// Create a compilation unit with the namespace


### PR DESCRIPTION
in the past, the register attribute was exclusively applied to the partial class defined in the *.designer.cs files.

however, xcsync uses roslyn for dotnet type processing and relies on the presence of the register attribute to detect if it is a type that should be synced to the Xcode environment.

so as is, after syncing the dotnet project is in a non-compilable state because of [CS0579 error](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs0579?f1url=%3FappId%3Droslyn%26k%3Dk(CS0579)). the simple fix is to just remove the extra, no longer needed register attribute during the sync back.

before:
![Screenshot 2024-11-05 at 12 58 49 PM](https://github.com/user-attachments/assets/01ae13d6-37a0-4ac7-a7fc-034187fb734d)

after:
![Screenshot 2024-11-05 at 12 56 22 PM](https://github.com/user-attachments/assets/bf2db37c-d354-4181-aeaf-eb76d11b980a)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/163)

expected test results need to be adjusted still..