### PR TITLE
Download files from xamarin-macios for both OSX and Linux the same way

### DIFF
--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -144,7 +144,7 @@
     <RemoveDir Directories="$(T4GeneratedFilesOutputPath)" />
   </Target>
   
-  <Target Name="GetLatestFrameworks_OSX" BeforeTargets="BeforeBuild" Inputs="@(DownloadFile)" Outputs="@(DownloadFile->'$(LatestFrameworksDownloadOutputPath)/%(Repo)/%(Identity)')" Condition="$([MSBuild]::IsOSPlatform(OSX))">
+  <Target Name="GetLatestFrameworks_OSX" BeforeTargets="BeforeBuild" Inputs="@(DownloadFile)" Outputs="@(DownloadFile->'$(LatestFrameworksDownloadOutputPath)/%(Repo)/%(Identity)')" Condition="$([MSBuild]::IsOSPlatform(OSX)) Or $([MSBuild]::IsOSPlatform(Linux))">
       <Exec Command="curl --create-dirs -f -s 'https://raw.githubusercontent.com/xamarin/%(DownloadFile.Repo)/%(DownloadFile.Hash)/%(DownloadFile.Identity)' --output '$(LatestFrameworksDownloadOutputPath)/%(DownloadFile.Repo)/%(DownloadFile.Identity)'" />
   </Target>
 


### PR DESCRIPTION
Missing the Linux OS condition on the MSBuild Exec command prevented the build from completing successfully when using a GitHub Codespace
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/172)