### PR TITLE
Properly discover csproj when ProjectPath is directory

### DIFF
--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -143,7 +143,7 @@ class BaseCommand<T> : Command {
 			}
 
 			LogDebug (Strings.Base.FoundProjectFile (csprojFiles [0], projectPath));
-			updatedPath = fileSystem.Path.Combine( fileSystem.Path.GetDirectoryName(projectPath) ?? string.Empty, csprojFiles [0] );
+			updatedPath = fileSystem.Path.Combine (fileSystem.Path.GetDirectoryName (projectPath) ?? string.Empty, csprojFiles [0]);
 		}
 
 		if (!fileSystem.File.Exists (updatedPath)) {

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -143,7 +143,7 @@ class BaseCommand<T> : Command {
 			}
 
 			LogDebug (Strings.Base.FoundProjectFile (csprojFiles [0], projectPath));
-			updatedPath = csprojFiles [0];
+			updatedPath = fileSystem.Path.Combine( fileSystem.Path.GetDirectoryName(projectPath) ?? string.Empty, csprojFiles [0] );
 		}
 
 		if (!fileSystem.File.Exists (updatedPath)) {


### PR DESCRIPTION
This change properly discovers the csproj when the [`-p`,`--project`] agument passed in is a directory, not the path to a csproj file. 

fixes: #57, #58
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/177)