### PR TITLE
improve MSBuildLocator API use

### DIFF
--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -46,15 +46,8 @@ static class xcSync {
 	static void RegisterMSBuild ()
 	{
 		if (!MSBuildLocator.IsRegistered) {
-			var msbuildInstances = MSBuildLocator.QueryVisualStudioInstances ()
-				.OrderByDescending (instance => instance.Version);
-
-			foreach (var instance in msbuildInstances)
-				Logger?.Debug ("Found MSBuild instance {0} at {1}", instance.Version, instance.MSBuildPath);
-			var msbuildInstance = msbuildInstances.First ();
-
-			// Register a specific instance of MSBuild
-			MSBuildLocator.RegisterInstance (msbuildInstance);
+			// API resolves the path to MSBuild via the .NET Core SDK
+			var msbuildInstance = MSBuildLocator.RegisterDefaults ();
 			Logger?.Debug ("Registered MSBuild instance {0} at {1}", msbuildInstance.Version, msbuildInstance.MSBuildPath);
 		}
 	}


### PR DESCRIPTION
Potentially fixes https://github.com/dotnet/xcsync/issues/179

Talked to the MSBuild team and got a bit more clarity here:
- the MSBuild Locator APIs have a number of variants and they're naming is a bit [misleading](https://learn.microsoft.com/en-us/dotnet/api/microsoft.build.locator.msbuildlocator.registerdefaults?view=msbuildlocator-1.5)..it's only on .NET framework the API exclusively discovers Visual Studio instances, but on .NET Core runtimes the API will discover installations of the .NET SDK
- And looking at the source code here, the RegisterDefaults API essentially takes care of what we were implementing here previously: https://github.com/microsoft/MSBuildLocator/blob/848a3edbe25fa0db52795e1efd7ff0d466cc004f/src/MSBuildLocator/MSBuildLocator.cs#L102-L117
- this is also the API used by other tools that rely on an SDK being installed but not necessarily VS, like the DevKit extension for VSCode.
- need to reach out to the tester who filed the issue to verify this fixes their problem
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/180)