### PR TITLE
[build] Address CVE-2024-43485, CVE-2024-38095

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,8 @@
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Wrappers" Version="$(TestableIOSystemIOAbstractionsWrappersPackageVersion)" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions.Analyzers" Version="$(TestableIOSystemIOAbstractionsAnalyzersPackageVersion)" />
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
+    <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
+    <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1PackageVersion)" />
     <!-- ClangSharp -->
     <PackageVersion Include="clangsharp" Version="$(ClangSharpPackageVersion)" />
     <PackageVersion Include="libClang.runtime.osx-arm64" Version="$(libClangRuntimeOsxArm64PackageVersion)" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -31,6 +31,8 @@
     <TestableIOSystemIOAbstractionsWrappersPackageVersion>21.0.2</TestableIOSystemIOAbstractionsWrappersPackageVersion>
     <TestableIOSystemIOAbstractionsAnalyzersPackageVersion>2022.0.0</TestableIOSystemIOAbstractionsAnalyzersPackageVersion>
     <NuGetFrameworksPackageVersion>6.11.1</NuGetFrameworksPackageVersion>
+    <SystemTextJsonPackageVersion>9.0.2</SystemTextJsonPackageVersion>
+    <SystemFormatsAsn1PackageVersion>9.0.2</SystemFormatsAsn1PackageVersion>
     <!-- ClangSharp -->
     <clangsharpPackageVersion>18.1.0</clangsharpPackageVersion>
     <libClangRuntimeOsxArm64PackageVersion>18.1.3</libClangRuntimeOsxArm64PackageVersion>

--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -76,8 +76,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Formats.Asn1" />
     <PackageReference Include="Microsoft.Extensions.Logging" />    
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Enrichers.Thread" />

--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -76,6 +76,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Formats.Asn1" Version="9.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" />    
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Enrichers.Thread" />


### PR DESCRIPTION
Context: https://github.com/advisories/GHSA-8g4q-xg66-9fp4
Context: https://github.com/advisories/GHSA-447r-wph3-92pm
Context: https://github.com/dotnet/xcsync/commit/1f6b6b2409f7ce9f1c4272f4c55f9a432215ac52

Commit https://github.com/dotnet/xcsync/commit/1f6b6b2409f7ce9f1c4272f4c55f9a432215ac52 updated Microsoft.CodeAnalysis package versions in an
attempt to address https://github.com/advisories/GHSA-8g4q-xg66-9fp4, however the v4.12.0 packages still
depend on System.Text.Json 8.0.4. Explicit references have been added
to System.Text.Json and System.Formats.Asn1 to address vulnerabilities.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/196)