### PR TITLE
Update System.Commandline to v2.5

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -26,7 +26,7 @@
     <SerilogExpressionsPackageVersion>4.0.0</SerilogExpressionsPackageVersion>
     <SerilogSinksConsolePackageVersion>5.0.1</SerilogSinksConsolePackageVersion>
     <SerilogSinksDebugPackageVersion>2.0.0</SerilogSinksDebugPackageVersion>
-    <SystemCommandLinePackageVersion>2.0.0-beta4.22272.1</SystemCommandLinePackageVersion>
+    <SystemCommandLinePackageVersion>2.0.0-beta5.25252.1</SystemCommandLinePackageVersion>
     <TestableIOSystemIOAbstractionsPackageVersion>21.0.2</TestableIOSystemIOAbstractionsPackageVersion>
     <TestableIOSystemIOAbstractionsWrappersPackageVersion>21.0.2</TestableIOSystemIOAbstractionsWrappersPackageVersion>
     <TestableIOSystemIOAbstractionsAnalyzersPackageVersion>2022.0.0</TestableIOSystemIOAbstractionsAnalyzersPackageVersion>

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -36,9 +36,9 @@ class BaseCommand<T> : Command {
 	protected string TargetPlatform => TryGetTargetPlatform (Tfm, out string targetPlatform) ? targetPlatform : string.Empty;
 	protected readonly IFileSystem fileSystem;
 
-	protected Option<string> project = new ( "project", ["--project", "-p"] ) {
+	protected Option<string> project = new ("project", ["--project", "-p"]) {
 		Description = Strings.Options.ProjectDescription,
-		DefaultValueFactory = (p) => "." 
+		DefaultValueFactory = (p) => "."
 	};
 
 	protected Option<string> tfm = new ("TargetFrameworkMoniker", ["--target-framework-moniker", "-tfm"]) {
@@ -75,7 +75,7 @@ class BaseCommand<T> : Command {
 		Validators.Add ((result) => {
 
 			if (!RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
-				result.AddError(Strings.Errors.Validation.InvalidOS);
+				result.AddError (Strings.Errors.Validation.InvalidOS);
 				return;
 			}
 

--- a/src/xcsync/Commands/GenerateCommand.cs
+++ b/src/xcsync/Commands/GenerateCommand.cs
@@ -12,10 +12,10 @@ class GenerateCommand : XcodeCommand<GenerateCommand> {
 
 	public GenerateCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "generate", Strings.Commands.GenerateDescription)
 	{
-		this.SetHandler (Execute);
+		SetAction (ExecuteAsync);
 	}
 
-	public async Task Execute ()
+	public async Task ExecuteAsync (ParseResult result, CancellationToken cancellationToken)
 	{
 		Logger?.Information (Strings.Generate.HeaderInformation, ProjectPath, TargetPath);
 

--- a/src/xcsync/Commands/SharedOptions.cs
+++ b/src/xcsync/Commands/SharedOptions.cs
@@ -7,18 +7,18 @@ namespace xcsync.Commands;
 
 static class SharedOptions {
 	public static readonly Option<Verbosity> Verbose =
-		new (["--verbosity", "-v"],
-			getDefaultValue: () => Verbosity.Normal) {
-			IsRequired = false,
+		new ("Verbosity", ["--verbosity", "-v"]) {
+			Description = Strings.Options.VerbosityDescription,
+			DefaultValueFactory = (p) => Verbosity.Normal,
+			Required = false,
 			Arity = ArgumentArity.ZeroOrOne,
-			Description = Strings.Options.VerbosityDescription
 		};
 
 	public static readonly Option<string> DotnetPath =
-		new (["--dotnet-path", "-d"],
-			getDefaultValue: () => string.Empty) {
-			IsRequired = false,
+		new ("DotNetPath", ["--dotnet-path", "-d"]) {
+			Description = Strings.Options.DotnetPathDescription,
+			DefaultValueFactory = (p) => string.Empty,
+			Required = false,
 			Arity = ArgumentArity.ZeroOrOne,
-			Description = Strings.Options.DotnetPathDescription
 		};
 }

--- a/src/xcsync/Commands/SyncCommand.cs
+++ b/src/xcsync/Commands/SyncCommand.cs
@@ -11,10 +11,10 @@ namespace xcsync.Commands;
 class SyncCommand : BaseCommand<SyncCommand> {
 	public SyncCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "sync", Strings.Commands.SyncDescription)
 	{
-		this.SetHandler (Execute);
+		SetAction (ExecuteAsync);
 	}
 
-	public async Task Execute ()
+	public async Task ExecuteAsync (ParseResult result, CancellationToken cancellationToken)
 	{
 		Logger?.Information (Strings.Sync.HeaderInformation, TargetPath, ProjectPath);
 

--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -4,7 +4,6 @@
 using System.Collections.Concurrent;
 using System.CommandLine;
 using System.IO.Abstractions;
-using System.Runtime.InteropServices;
 using Serilog;
 using xcsync.Projects;
 
@@ -13,12 +12,15 @@ namespace xcsync.Commands;
 class WatchCommand : XcodeCommand<WatchCommand> {
 
 	public WatchCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "watch", Strings.Commands.WatchDescription)
-	{
-		this.SetHandler (Execute, project, target, tfm, force, open);
+	{		
+		SetAction (ExecuteAsync);
 	}
 
-	public async Task Execute (string project, string target, string tfm, bool force, bool open)
-	{
+	public async Task ExecuteAsync (ParseResult result, CancellationToken cancellationToken)
+	{		
+		var open = result.GetValue (this.open);
+		var force = result.GetValue (this.force);
+
 		using var cts = new CancellationTokenSource ();
 
 		// Occurs when Ctrl+C or Ctrl+Break is pressed.

--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -12,12 +12,12 @@ namespace xcsync.Commands;
 class WatchCommand : XcodeCommand<WatchCommand> {
 
 	public WatchCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "watch", Strings.Commands.WatchDescription)
-	{		
+	{
 		SetAction (ExecuteAsync);
 	}
 
 	public async Task ExecuteAsync (ParseResult result, CancellationToken cancellationToken)
-	{		
+	{
 		var open = result.GetValue (this.open);
 		var force = result.GetValue (this.force);
 

--- a/src/xcsync/Commands/XcSyncCommand.cs
+++ b/src/xcsync/Commands/XcSyncCommand.cs
@@ -17,8 +17,8 @@ class XcSyncCommand : RootCommand {
 		Logger = logger ?? xcSync.Logger!
 			.ForContext ("SourceContext", typeof (XcSyncCommand).Name.Replace ("Command", string.Empty).ToLowerInvariant ());
 
-		Options.Add( SharedOptions.Verbose);
-		Options.Add( SharedOptions.DotnetPath);
+		Options.Add (SharedOptions.Verbose);
+		Options.Add (SharedOptions.DotnetPath);
 
 		SharedOptions.Verbose.Validators.Add (result => {
 			try {
@@ -35,7 +35,7 @@ class XcSyncCommand : RootCommand {
 					_ => LogEventLevel.Information,
 				};
 			} catch (InvalidOperationException) {
-				result.AddError(Strings.Errors.Validation.InvalidVerbosity);
+				result.AddError (Strings.Errors.Validation.InvalidVerbosity);
 			}
 		});
 

--- a/src/xcsync/Commands/XcodeCommand.cs
+++ b/src/xcsync/Commands/XcodeCommand.cs
@@ -12,15 +12,15 @@ class XcodeCommand<T> : BaseCommand<T> {
 	protected bool Force { get; private set; }
 	protected bool Open { get; private set; }
 
-	protected Option<bool> force = new (
-		["--force", "-f"],
-		description: Strings.Options.ForceDescription,
-		getDefaultValue: () => false);
+	protected Option<bool> force = new ("Force", ["--force", "-f"]) {
+		Description = Strings.Options.ForceDescription,
+		DefaultValueFactory = (p) => false,
+	};
 
-	protected Option<bool> open = new (
-		["--open", "-o"],
-		description: Strings.Options.OpenDescription,
-		getDefaultValue: () => false);
+	protected Option<bool> open = new ("Open", ["--open", "-o"]) {
+		Description = Strings.Options.OpenDescription,
+		DefaultValueFactory = (p) => false,
+	};
 
 	public XcodeCommand (IFileSystem fileSystem, ILogger logger, string name, string description) : base (fileSystem, logger, name, description)
 	{ }
@@ -34,9 +34,9 @@ class XcodeCommand<T> : BaseCommand<T> {
 
 	protected override void AddValidators ()
 	{
-		AddValidator ((result) => {
-			Force = result.GetValueForOption (force);
-			Open = result.GetValueForOption (open);
+		Validators.Add ((result) => {
+			Force = result.GetValue (force);
+			Open = result.GetValue (open);
 		});
 		base.AddValidators ();
 	}

--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Microsoft.Build.Locator;
@@ -36,10 +34,7 @@ static class xcSync {
 
 		RegisterMSBuild ();
 
-		var parser = new CommandLineBuilder (new XcSyncCommand (FileSystem))
-			.UseDefaults ()
-			.Build ();
-
+		var parser = new CommandLineConfiguration (new XcSyncCommand (FileSystem));
 		return await parser.InvokeAsync (args).ConfigureAwait (false);
 	}
 


### PR DESCRIPTION
Upgrade System.Commandline to v2.5+

NuGet package aren't currently available for all dependencies fo 2.5, so this needs to be held until all package are held. 

ToDo:
- [x] Update xcsync to new 2.5 API's
- [ ] Update tests to new 2.5 API's
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/225)