### PR TITLE
Pin transitive Microsoft.Build dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,8 @@
     <!-- <PackageVersion Include="" Version="" /> -->
     <PackageVersion Include="Marille" Version="$(MarillePackageVersion)" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="$(MicrosoftBuildLocatorPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisPackageVersion)" />


### PR DESCRIPTION
Pins `Microsoft.Build.Tasks.Core` and `Microsoft.Build.Utilities.Core` to the same version as `Microsoft.Build` via central package management.

These transitive dependencies were resolving to an older version (17.7.2) despite `Microsoft.Build` being at 17.11.4. This adds explicit version pins to keep them aligned.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/237)