### PR TITLE
Fix 183 - h/m files are not generated for file with namespaces with dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,6 +397,9 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 
+# OSX
+.DS_Store
+
 # Repository specific 
 .packages
 .dotnet

--- a/eng/pipelines/templates/buildandtest.yml
+++ b/eng/pipelines/templates/buildandtest.yml
@@ -54,11 +54,11 @@ steps:
         $workloadSetVersion = "${$jsonContent.sdk.version}.0"
 
         # Update/install workloads to the workload set
-        dotnet workload update --source https://api.nuget.org/v3/index.json --version $workloadSetVersion
-        dotnet workload install macos ios maccatalyst tvos maui --source https://api.nuget.org/v3/index.json --version 8.0.402.0 # Neccessary for tests
+        ${{ parameters.dotnetScript }} workload update --source https://api.nuget.org/v3/index.json --version $workloadSetVersion
+        ${{ parameters.dotnetScript }} workload install macos ios maccatalyst tvos maui --source https://api.nuget.org/v3/index.json --version 8.0.402.0 # Neccessary for tests
 
         # List installed workloads
-        dotnet workload list        
+        ${{ parameters.dotnetScript }} workload list        
       displayName: Install workloads
 
     - ${{ if ne(parameters.isWindows, 'true') }}:

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -10,294 +10,294 @@ namespace xcsync.Projects;
 
 // Type system bridge between .NET and Xcode
 class TypeService (ILogger Logger) : ITypeService {
-    static IFileSystem FileSystem { get; set; } = new FileSystem ();
+	static IFileSystem FileSystem { get; set; } = new FileSystem ();
 
-    // Init
-    readonly ConcurrentDictionary<string, TypeMapping?> clrTypes = new ();
-    readonly ConcurrentDictionary<string, TypeMapping> objCTypes = new ();
+	// Init
+	readonly ConcurrentDictionary<string, TypeMapping?> clrTypes = new ();
+	readonly ConcurrentDictionary<string, TypeMapping> objCTypes = new ();
 
-    public readonly ConcurrentDictionary<string, Compilation> compilations = new ();
+	public readonly ConcurrentDictionary<string, Compilation> compilations = new ();
 
-    static IEnumerable<INamespaceSymbol> GetAllNamespaces (INamespaceSymbol root)
-    {
-        foreach (var ns in root.GetNamespaceMembers ()) {
-            yield return ns;
-            foreach (var child in GetAllNamespaces (ns)) {
-                yield return child;
-            }
-        }
-    }
+	static IEnumerable<INamespaceSymbol> GetAllNamespaces (INamespaceSymbol root)
+	{
+		foreach (var ns in root.GetNamespaceMembers ()) {
+			yield return ns;
+			foreach (var child in GetAllNamespaces (ns)) {
+				yield return child;
+			}
+		}
+	}
 
-    // Add, register new type mapping
-    public TypeMapping? AddType (TypeMapping newType)
-    {
-        if (!clrTypes.TryAdd (newType.ClrType, newType)) {
-            Logger.Error (Strings.TypeService.DuplicateType (newType.ClrType), newType.ClrType);
-            return null;
-        }
+	// Add, register new type mapping
+	public TypeMapping? AddType (TypeMapping newType)
+	{
+		if (!clrTypes.TryAdd (newType.ClrType, newType)) {
+			Logger.Error (Strings.TypeService.DuplicateType (newType.ClrType), newType.ClrType);
+			return null;
+		}
 
-        if (!objCTypes.TryAdd (newType.ObjCType, newType)) {
-            clrTypes.TryRemove (newType.ClrType, out _);
-            Logger.Error (Strings.TypeService.DuplicateType (newType.ObjCType), newType.ObjCType);
-            return null;
-        }
+		if (!objCTypes.TryAdd (newType.ObjCType, newType)) {
+			clrTypes.TryRemove (newType.ClrType, out _);
+			Logger.Error (Strings.TypeService.DuplicateType (newType.ObjCType), newType.ObjCType);
+			return null;
+		}
 
-        return newType;
-    }
+		return newType;
+	}
 
-    public TypeMapping? AddType (INamedTypeSymbol typeSymbol, string clrType, string objCType, TypeMapping? baseType, bool isModel, bool isProtocol,
-        bool inDesigner, List<IBOutlet>? outlets, List<IBAction>? actions, HashSet<string> references)
-    {
-        var newType = new TypeMapping (typeSymbol, clrType, objCType, baseType, isModel, isProtocol, inDesigner, outlets, actions, references);
-        return AddType (newType);
-    }
+	public TypeMapping? AddType (INamedTypeSymbol typeSymbol, string clrType, string objCType, TypeMapping? baseType, bool isModel, bool isProtocol,
+		bool inDesigner, List<IBOutlet>? outlets, List<IBAction>? actions, HashSet<string> references)
+	{
+		var newType = new TypeMapping (typeSymbol, clrType, objCType, baseType, isModel, isProtocol, inDesigner, outlets, actions, references);
+		return AddType (newType);
+	}
 
-    public async Task<bool> TryUpdateMappingAsync (TypeMapping oldMapping, SyntaxNode newSyntax)
-    {
-        var compilation = await UpdateCompilation (oldMapping.TypeSymbol!, newSyntax).ConfigureAwait (false);
+	public async Task<bool> TryUpdateMappingAsync (TypeMapping oldMapping, SyntaxNode newSyntax)
+	{
+		var compilation = await UpdateCompilation (oldMapping.TypeSymbol!, newSyntax).ConfigureAwait (false);
 
-        TypeMapping? newMapping = UpdateMappingFromCompilation (oldMapping, compilation);
+		TypeMapping? newMapping = UpdateMappingFromCompilation (oldMapping, compilation);
 
-        if (newMapping is null) {
-            Logger.Error (Strings.TypeService.TypeNotFound (oldMapping.ClrType));
-            return false;
-        }
+		if (newMapping is null) {
+			Logger.Error (Strings.TypeService.TypeNotFound (oldMapping.ClrType));
+			return false;
+		}
 
-        if (oldMapping.ClrType != newMapping.ClrType || oldMapping.ObjCType != newMapping.ObjCType) {
-            Logger.Error (Strings.TypeService.MappingMismatch (oldMapping.ClrType, oldMapping.ObjCType, newMapping.ClrType, newMapping.ObjCType));
-            return false;
-        }
-        bool success = clrTypes.TryGetValue (oldMapping.ClrType, out var existingClrMapping);
-        success &= objCTypes.TryGetValue (oldMapping.ObjCType, out var existingObjCMapping);
+		if (oldMapping.ClrType != newMapping.ClrType || oldMapping.ObjCType != newMapping.ObjCType) {
+			Logger.Error (Strings.TypeService.MappingMismatch (oldMapping.ClrType, oldMapping.ObjCType, newMapping.ClrType, newMapping.ObjCType));
+			return false;
+		}
+		bool success = clrTypes.TryGetValue (oldMapping.ClrType, out var existingClrMapping);
+		success &= objCTypes.TryGetValue (oldMapping.ObjCType, out var existingObjCMapping);
 
-        if (!success || existingClrMapping is null || existingObjCMapping is null) {
-            Logger.Error (Strings.TypeService.MappingNotFound (oldMapping.ClrType, oldMapping.ObjCType));
-            return false;
-        }
+		if (!success || existingClrMapping is null || existingObjCMapping is null) {
+			Logger.Error (Strings.TypeService.MappingNotFound (oldMapping.ClrType, oldMapping.ObjCType));
+			return false;
+		}
 
-        if (clrTypes.TryUpdate (oldMapping.ClrType, newMapping, existingClrMapping)) {
-            if (!objCTypes.TryUpdate (oldMapping.ObjCType, newMapping, existingObjCMapping)) {
-                Logger.Error (Strings.TypeService.MappingUpdateFailed (oldMapping.ClrType, oldMapping.ObjCType));
-                clrTypes.TryUpdate (oldMapping.ClrType, existingClrMapping, newMapping);
-                return false;
-            }
-        };
-        return true;
-    }
+		if (clrTypes.TryUpdate (oldMapping.ClrType, newMapping, existingClrMapping)) {
+			if (!objCTypes.TryUpdate (oldMapping.ObjCType, newMapping, existingObjCMapping)) {
+				Logger.Error (Strings.TypeService.MappingUpdateFailed (oldMapping.ClrType, oldMapping.ObjCType));
+				clrTypes.TryUpdate (oldMapping.ClrType, existingClrMapping, newMapping);
+				return false;
+			}
+		};
+		return true;
+	}
 
-    TypeMapping? UpdateMappingFromCompilation (TypeMapping oldMapping, Compilation compilation)
-    {
-        var newMapping = GetAllNamespaces (compilation.GlobalNamespace)
-            .Where (ns => ns.GetMembers ()
-                .Any (member => member.Locations
-                    .Any (location => location.IsInSource)))
-            .SelectMany (ns => ns.GetTypeMembers ())
-            .Where (type => xcSync.IsNsoDerived (type) && type.Name == oldMapping.ClrType)
-            .Select (type => oldMapping with { TypeSymbol = type, HasChanges = true })
-            .FirstOrDefault ();
+	TypeMapping? UpdateMappingFromCompilation (TypeMapping oldMapping, Compilation compilation)
+	{
+		var newMapping = GetAllNamespaces (compilation.GlobalNamespace)
+			.Where (ns => ns.GetMembers ()
+				.Any (member => member.Locations
+					.Any (location => location.IsInSource)))
+			.SelectMany (ns => ns.GetTypeMembers ())
+			.Where (type => xcSync.IsNsoDerived (type) && type.Name == oldMapping.ClrType)
+			.Select (type => oldMapping with { TypeSymbol = type, HasChanges = true })
+			.FirstOrDefault ();
 
-        return newMapping;
-    }
+		return newMapping;
+	}
 
-    public virtual IEnumerable<TypeMapping?> QueryTypes (string? clrType = null, string? objcType = null) =>
-        (clrType, objcType) switch {
-            (string cli, null) => clrTypes.Values.Where (t => t?.ClrType == cli),
-            (null, string objc) => objCTypes.Values.Where (t => t?.ObjCType == objc),
-            (string clr, string objc) => clrTypes.Values.Where (t => t?.ClrType == clr && t.ObjCType == objc),
-            _ => clrTypes.Values
-        };
+	public virtual IEnumerable<TypeMapping?> QueryTypes (string? clrType = null, string? objcType = null) =>
+		(clrType, objcType) switch {
+			(string cli, null) => clrTypes.Values.Where (t => t?.ClrType == cli),
+			(null, string objc) => objCTypes.Values.Where (t => t?.ObjCType == objc),
+			(string clr, string objc) => clrTypes.Values.Where (t => t?.ClrType == clr && t.ObjCType == objc),
+			_ => clrTypes.Values
+		};
 
-    public void AddCompilation (string targetPlatform, Compilation compilation)
-    {
-        if (compilation.AssemblyName is null) {
-            Logger.Error (Strings.TypeService.MissingAssemblyName);
-            return;
-        }
+	public void AddCompilation (string targetPlatform, Compilation compilation)
+	{
+		if (compilation.AssemblyName is null) {
+			Logger.Error (Strings.TypeService.MissingAssemblyName);
+			return;
+		}
 
-        if (!compilations.TryAdd (compilation.AssemblyName, compilation)) {
-            Logger.Error (Strings.TypeService.DuplicateCompilation (compilation.AssemblyName), compilation.AssemblyName);
-        };
+		if (!compilations.TryAdd (compilation.AssemblyName, compilation)) {
+			Logger.Error (Strings.TypeService.DuplicateCompilation (compilation.AssemblyName), compilation.AssemblyName);
+		};
 
-        AddTypesFromCompilation (targetPlatform, compilation);
-    }
+		AddTypesFromCompilation (targetPlatform, compilation);
+	}
 
-    async Task<Compilation> UpdateCompilation (INamedTypeSymbol typeSymbol, SyntaxNode newSyntax)
-    {
-        if (!compilations.TryGetValue (typeSymbol.ContainingAssembly.Name, out var compilation)) {
-            Logger.Error (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
-            throw new InvalidOperationException (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
-        }
+	async Task<Compilation> UpdateCompilation (INamedTypeSymbol typeSymbol, SyntaxNode newSyntax)
+	{
+		if (!compilations.TryGetValue (typeSymbol.ContainingAssembly.Name, out var compilation)) {
+			Logger.Error (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
+			throw new InvalidOperationException (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
+		}
 
-        var root = await compilation.SyntaxTrees.First (st => st.FilePath == newSyntax.SyntaxTree.FilePath).GetRootAsync ();
-        if (root is null) {
-            Logger.Error (Strings.TypeService.SyntaxRootNotFound (typeSymbol.Name));
-            return compilation;
-        }
+		var root = await compilation.SyntaxTrees.First (st => st.FilePath == newSyntax.SyntaxTree.FilePath).GetRootAsync ();
+		if (root is null) {
+			Logger.Error (Strings.TypeService.SyntaxRootNotFound (typeSymbol.Name));
+			return compilation;
+		}
 
-        var newModel = compilation.ReplaceSyntaxTree (root.SyntaxTree, newSyntax.SyntaxTree);
+		var newModel = compilation.ReplaceSyntaxTree (root.SyntaxTree, newSyntax.SyntaxTree);
 
-        if (newModel.GetDiagnostics ().Any (diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)) {
-            Logger.Verbose (Strings.TypeService.CompilationErrorsFound (newModel.AssemblyName!));
-            foreach (var diagnostic in newModel.GetDiagnostics ()) {
-                if (diagnostic.Severity == DiagnosticSeverity.Error) {
-                    Logger.Verbose (Strings.TypeService.AssemblyDiagnosticError (newModel.AssemblyName!, diagnostic.ToString ()));
-                }
-            }
-        }
+		if (newModel.GetDiagnostics ().Any (diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)) {
+			Logger.Verbose (Strings.TypeService.CompilationErrorsFound (newModel.AssemblyName!));
+			foreach (var diagnostic in newModel.GetDiagnostics ()) {
+				if (diagnostic.Severity == DiagnosticSeverity.Error) {
+					Logger.Verbose (Strings.TypeService.AssemblyDiagnosticError (newModel.AssemblyName!, diagnostic.ToString ()));
+				}
+			}
+		}
 
-        if (newModel.AssemblyName is null) {
-            Logger.Error (Strings.TypeService.MissingAssemblyName);
-            return compilation;
-        }
+		if (newModel.AssemblyName is null) {
+			Logger.Error (Strings.TypeService.MissingAssemblyName);
+			return compilation;
+		}
 
-        if (!compilations.TryUpdate (newModel.AssemblyName, newModel, compilation))
-            Logger.Error (Strings.TypeService.AssemblyUpdateError (compilation.AssemblyName!));
+		if (!compilations.TryUpdate (newModel.AssemblyName, newModel, compilation))
+			Logger.Error (Strings.TypeService.AssemblyUpdateError (compilation.AssemblyName!));
 
-        return newModel;
-    }
+		return newModel;
+	}
 
-    void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
-    {
-        // limit scope of namespaces to only those that contain NSObject derived types.
-        var namespaces = GetAllNamespaces (compilation.GlobalNamespace)
-            .Where (ns => ns.GetTypeMembers ()
-                .Any (xcSync.IsNsoDerived));
+	void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
+	{
+		// limit scope of namespaces to only those that contain NSObject derived types.
+		var namespaces = GetAllNamespaces (compilation.GlobalNamespace)
+			.Where (ns => ns.GetTypeMembers ()
+				.Any (xcSync.IsNsoDerived));
 
-        if (namespaces is null)
-            return;
+		if (namespaces is null)
+			return;
 
-        foreach (var ns in namespaces) {
-            foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
-                var nsType = ConvertToTypeMapping (targetPlatform, type);
-                if (nsType is not null) {
-                    AddType (nsType with { IsInSource = type.Locations.Any (l => l.IsInSource) });
-                }
-            }
-        }
-    }
+		foreach (var ns in namespaces) {
+			foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
+				var nsType = ConvertToTypeMapping (targetPlatform, type);
+				if (nsType is not null) {
+					AddType (nsType with { IsInSource = type.Locations.Any (l => l.IsInSource) });
+				}
+			}
+		}
+	}
 
-    TypeMapping? ConvertToTypeMapping (string targetPlatform, INamedTypeSymbol type)
-    {
-        // TypeMapping bridges the gap between the .net + objc worlds
-        // extracts the necessary info from the roslyn detected type for objc .h and .m file generation
-        // so this method is orchestrating the conversion of the roslyn type to TypeMapping
+	TypeMapping? ConvertToTypeMapping (string targetPlatform, INamedTypeSymbol type)
+	{
+		// TypeMapping bridges the gap between the .net + objc worlds
+		// extracts the necessary info from the roslyn detected type for objc .h and .m file generation
+		// so this method is orchestrating the conversion of the roslyn type to TypeMapping
 
-        // If the type is not a model, we handle the properties and methods for IBOutlets and IBActions handling too
-        var isModel = false;
-        var isProtocol = false;
-        var clrName = type.MetadataName;
-        var objCName = type.Name;
-        HashSet<string> refs = [];
+		// If the type is not a model, we handle the properties and methods for IBOutlets and IBActions handling too
+		var isModel = false;
+		var isProtocol = false;
+		var clrName = type.MetadataName;
+		var objCName = type.Name;
+		HashSet<string> refs = [];
 
-        if (clrTypes.TryGetValue (clrName, out var existingTypeMapping))
-            return existingTypeMapping;
+		if (clrTypes.TryGetValue (clrName, out var existingTypeMapping))
+			return existingTypeMapping;
 
-        var baseType = type.BaseType;
-        if (baseType is null) {
-            clrTypes [clrName] = null; // this saves computing the type multiple times and failing each type
-            return null;
-        }
+		var baseType = type.BaseType;
+		if (baseType is null) {
+			clrTypes [clrName] = null; // this saves computing the type multiple times and failing each type
+			return null;
+		}
 
-        var baseTypeMapping = ConvertToTypeMapping (targetPlatform, baseType);
+		var baseTypeMapping = ConvertToTypeMapping (targetPlatform, baseType);
 
-        foreach (var a in type.GetAttributes ()) {
-            switch (a.AttributeClass?.Name) {
-            case "ProtocolAttribute":
-                isProtocol = true;
-                break;
-            case "ModelAttribute":
-                isModel = true;
-                break;
-            case "RegisterAttribute":
-                objCName = a.ConstructorArguments.Length > 0
-                    ? GetName (a) ?? objCName
-                    : objCName;
-                break;
-            }
-        }
+		foreach (var a in type.GetAttributes ()) {
+			switch (a.AttributeClass?.Name) {
+			case "ProtocolAttribute":
+				isProtocol = true;
+				break;
+			case "ModelAttribute":
+				isModel = true;
+				break;
+			case "RegisterAttribute":
+				objCName = a.ConstructorArguments.Length > 0
+					? GetName (a) ?? objCName
+					: objCName;
+				break;
+			}
+		}
 
-        List<IBOutlet> outlets = [];
-        List<IBAction> actions = [];
+		List<IBOutlet> outlets = [];
+		List<IBAction> actions = [];
 
-        if (!isModel) {
+		if (!isModel) {
 
-            foreach (var property in type.GetMembers ().OfType<IPropertySymbol> ()) {
+			foreach (var property in type.GetMembers ().OfType<IPropertySymbol> ()) {
 
-                var outletAttribute = GetAttribute (property, "OutletAttribute");
+				var outletAttribute = GetAttribute (property, "OutletAttribute");
 
-                if (outletAttribute is null)
-                    continue;
+				if (outletAttribute is null)
+					continue;
 
-                outlets.Add (new IBOutlet (
-                    clrName: property.Name,
-                    objcName: GetName (outletAttribute) ?? property.Name,
-                    clrType: property.Type.MetadataName,
-                    objcType: GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type),
-                    isCollection: property.Type.TypeKind == TypeKind.Array));
+				outlets.Add (new IBOutlet (
+					clrName: property.Name,
+					objcName: GetName (outletAttribute) ?? property.Name,
+					clrType: property.Type.MetadataName,
+					objcType: GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type),
+					isCollection: property.Type.TypeKind == TypeKind.Array));
 
-                refs.Add (property.ContainingNamespace.Name);
-            }
+				refs.Add (property.ContainingNamespace.Name);
+			}
 
-            foreach (var method in type.GetMembers ().OfType<IMethodSymbol> ()) {
+			foreach (var method in type.GetMembers ().OfType<IMethodSymbol> ()) {
 
-                var actionAttribute = GetAttribute (method, "ActionAttribute");
+				var actionAttribute = GetAttribute (method, "ActionAttribute");
 
-                if (actionAttribute is null)
-                    continue;
+				if (actionAttribute is null)
+					continue;
 
-                var actionName = GetName (actionAttribute);
-                (string? objcName, string []? strings) = GetInfo (method, actionName);
+				var actionName = GetName (actionAttribute);
+				(string? objcName, string []? strings) = GetInfo (method, actionName);
 
-                List<IBActionParameter> parameters = new (method.Parameters.Length);
+				List<IBActionParameter> parameters = new (method.Parameters.Length);
 
-                var index = 0;
-                foreach (var param in method.Parameters) {
-                    parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type)));
-                    index++;
-                    refs.Add (param.ContainingNamespace.Name);
-                }
+				var index = 0;
+				foreach (var param in method.Parameters) {
+					parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type)));
+					index++;
+					refs.Add (param.ContainingNamespace.Name);
+				}
 
-                actions.Add (new IBAction (method.Name, objcName, parameters));
-            }
-        }
+				actions.Add (new IBAction (method.Name, objcName, parameters));
+			}
+		}
 
-        refs.Add (type.ContainingNamespace.Name);
+		refs.Add (type.ContainingNamespace.Name);
 
-        if (baseTypeMapping is not null)
-            refs.UnionWith (baseTypeMapping.References);
+		if (baseTypeMapping is not null)
+			refs.UnionWith (baseTypeMapping.References);
 
-        var typeMapping = new TypeMapping (type, clrName, objCName, baseTypeMapping, isModel, isProtocol, InDesignerFile (type, objCName),
-            outlets.Count == 0 ? null : outlets, actions.Count == 0 ? null : actions,
-            refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ());
+		var typeMapping = new TypeMapping (type, clrName, objCName, baseTypeMapping, isModel, isProtocol, InDesignerFile (type, objCName),
+			outlets.Count == 0 ? null : outlets, actions.Count == 0 ? null : actions,
+			refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ());
 
-        return typeMapping;
-    }
+		return typeMapping;
+	}
 
-    bool InDesignerFile (ITypeSymbol type, string objCName)
-    {
-        var source = type.Locations.FirstOrDefault ()?.SourceTree;
-        var sourceDir = FileSystem.Path.GetDirectoryName (source?.FilePath) ?? string.Empty;
-        return FileSystem.File.Exists (FileSystem.Path.Combine (sourceDir, $"{objCName}.designer.cs"));
-    }
+	bool InDesignerFile (ITypeSymbol type, string objCName)
+	{
+		var source = type.Locations.FirstOrDefault ()?.SourceTree;
+		var sourceDir = FileSystem.Path.GetDirectoryName (source?.FilePath) ?? string.Empty;
+		return FileSystem.File.Exists (FileSystem.Path.Combine (sourceDir, $"{objCName}.designer.cs"));
+	}
 
-    static AttributeData? GetAttribute (ISymbol symbol, string attributeName) =>
-        symbol.GetAttributes ().FirstOrDefault (a => a.AttributeClass?.Name == attributeName);
+	static AttributeData? GetAttribute (ISymbol symbol, string attributeName) =>
+		symbol.GetAttributes ().FirstOrDefault (a => a.AttributeClass?.Name == attributeName);
 
-    static string? GetName (AttributeData attribute) =>
-        attribute.ConstructorArguments.FirstOrDefault ().Value?.ToString ();
+	static string? GetName (AttributeData attribute) =>
+		attribute.ConstructorArguments.FirstOrDefault ().Value?.ToString ();
 
-    string? GetObjCType (string targetPlatform, INamedTypeSymbol symbol)
-    {
-        clrTypes.TryGetValue (symbol.MetadataName, out var nsType);
-        return nsType?.ObjCType ?? ConvertToTypeMapping (targetPlatform, symbol)?.ObjCType;
-    }
+	string? GetObjCType (string targetPlatform, INamedTypeSymbol symbol)
+	{
+		clrTypes.TryGetValue (symbol.MetadataName, out var nsType);
+		return nsType?.ObjCType ?? ConvertToTypeMapping (targetPlatform, symbol)?.ObjCType;
+	}
 
-    static (string objcName, string []? @params) GetInfo (IMethodSymbol method, string? actionAttributeName)
-    {
-        if (actionAttributeName is null)
-            return (method.Name, null);
-        var split = actionAttributeName.Split (":", StringSplitOptions.TrimEntries);
-        return split.Length > 1 ? (split [0], split [1..]) : (split [0], null);
-    }
+	static (string objcName, string []? @params) GetInfo (IMethodSymbol method, string? actionAttributeName)
+	{
+		if (actionAttributeName is null)
+			return (method.Name, null);
+		var split = actionAttributeName.Split (":", StringSplitOptions.TrimEntries);
+		return split.Length > 1 ? (split [0], split [1..]) : (split [0], null);
+	}
 
 }

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -10,289 +10,294 @@ namespace xcsync.Projects;
 
 // Type system bridge between .NET and Xcode
 class TypeService (ILogger Logger) : ITypeService {
-	static IFileSystem FileSystem { get; set; } = new FileSystem ();
+    static IFileSystem FileSystem { get; set; } = new FileSystem ();
 
-	// Init
-	readonly ConcurrentDictionary<string, TypeMapping?> clrTypes = new ();
-	readonly ConcurrentDictionary<string, TypeMapping> objCTypes = new ();
+    // Init
+    readonly ConcurrentDictionary<string, TypeMapping?> clrTypes = new ();
+    readonly ConcurrentDictionary<string, TypeMapping> objCTypes = new ();
 
-	public readonly ConcurrentDictionary<string, Compilation> compilations = new ();
+    public readonly ConcurrentDictionary<string, Compilation> compilations = new ();
 
-	// Add, register new type mapping
-	public TypeMapping? AddType (TypeMapping newType)
-	{
-		if (!clrTypes.TryAdd (newType.ClrType, newType)) {
-			Logger.Error (Strings.TypeService.DuplicateType (newType.ClrType), newType.ClrType);
-			return null;
-		}
+    static IEnumerable<INamespaceSymbol> GetAllNamespaces (INamespaceSymbol root)
+    {
+        foreach (var ns in root.GetNamespaceMembers ()) {
+            yield return ns;
+            foreach (var child in GetAllNamespaces (ns)) {
+                yield return child;
+            }
+        }
+    }
 
-		if (!objCTypes.TryAdd (newType.ObjCType, newType)) {
-			clrTypes.TryRemove (newType.ClrType, out _);
-			Logger.Error (Strings.TypeService.DuplicateType (newType.ObjCType), newType.ObjCType);
-			return null;
-		}
+    // Add, register new type mapping
+    public TypeMapping? AddType (TypeMapping newType)
+    {
+        if (!clrTypes.TryAdd (newType.ClrType, newType)) {
+            Logger.Error (Strings.TypeService.DuplicateType (newType.ClrType), newType.ClrType);
+            return null;
+        }
 
-		return newType;
-	}
+        if (!objCTypes.TryAdd (newType.ObjCType, newType)) {
+            clrTypes.TryRemove (newType.ClrType, out _);
+            Logger.Error (Strings.TypeService.DuplicateType (newType.ObjCType), newType.ObjCType);
+            return null;
+        }
 
-	public TypeMapping? AddType (INamedTypeSymbol typeSymbol, string clrType, string objCType, TypeMapping? baseType, bool isModel, bool isProtocol,
-		bool inDesigner, List<IBOutlet>? outlets, List<IBAction>? actions, HashSet<string> references)
-	{
-		var newType = new TypeMapping (typeSymbol, clrType, objCType, baseType, isModel, isProtocol, inDesigner, outlets, actions, references);
-		return AddType (newType);
-	}
+        return newType;
+    }
 
-	public async Task<bool> TryUpdateMappingAsync (TypeMapping oldMapping, SyntaxNode newSyntax)
-	{
-		var compilation = await UpdateCompilation (oldMapping.TypeSymbol!, newSyntax).ConfigureAwait (false);
+    public TypeMapping? AddType (INamedTypeSymbol typeSymbol, string clrType, string objCType, TypeMapping? baseType, bool isModel, bool isProtocol,
+        bool inDesigner, List<IBOutlet>? outlets, List<IBAction>? actions, HashSet<string> references)
+    {
+        var newType = new TypeMapping (typeSymbol, clrType, objCType, baseType, isModel, isProtocol, inDesigner, outlets, actions, references);
+        return AddType (newType);
+    }
 
-		TypeMapping? newMapping = UpdateMappingFromCompilation (oldMapping, compilation);
+    public async Task<bool> TryUpdateMappingAsync (TypeMapping oldMapping, SyntaxNode newSyntax)
+    {
+        var compilation = await UpdateCompilation (oldMapping.TypeSymbol!, newSyntax).ConfigureAwait (false);
 
-		if (newMapping is null) {
-			Logger.Error (Strings.TypeService.TypeNotFound (oldMapping.ClrType));
-			return false;
-		}
+        TypeMapping? newMapping = UpdateMappingFromCompilation (oldMapping, compilation);
 
-		if (oldMapping.ClrType != newMapping.ClrType || oldMapping.ObjCType != newMapping.ObjCType) {
-			Logger.Error (Strings.TypeService.MappingMismatch (oldMapping.ClrType, oldMapping.ObjCType, newMapping.ClrType, newMapping.ObjCType));
-			return false;
-		}
-		bool success = clrTypes.TryGetValue (oldMapping.ClrType, out var existingClrMapping);
-		success &= objCTypes.TryGetValue (oldMapping.ObjCType, out var existingObjCMapping);
+        if (newMapping is null) {
+            Logger.Error (Strings.TypeService.TypeNotFound (oldMapping.ClrType));
+            return false;
+        }
 
-		if (!success || existingClrMapping is null || existingObjCMapping is null) {
-			Logger.Error (Strings.TypeService.MappingNotFound (oldMapping.ClrType, oldMapping.ObjCType));
-			return false;
-		}
+        if (oldMapping.ClrType != newMapping.ClrType || oldMapping.ObjCType != newMapping.ObjCType) {
+            Logger.Error (Strings.TypeService.MappingMismatch (oldMapping.ClrType, oldMapping.ObjCType, newMapping.ClrType, newMapping.ObjCType));
+            return false;
+        }
+        bool success = clrTypes.TryGetValue (oldMapping.ClrType, out var existingClrMapping);
+        success &= objCTypes.TryGetValue (oldMapping.ObjCType, out var existingObjCMapping);
 
-		if (clrTypes.TryUpdate (oldMapping.ClrType, newMapping, existingClrMapping)) {
-			if (!objCTypes.TryUpdate (oldMapping.ObjCType, newMapping, existingObjCMapping)) {
-				Logger.Error (Strings.TypeService.MappingUpdateFailed (oldMapping.ClrType, oldMapping.ObjCType));
-				clrTypes.TryUpdate (oldMapping.ClrType, existingClrMapping, newMapping);
-				return false;
-			}
-		};
-		return true;
-	}
+        if (!success || existingClrMapping is null || existingObjCMapping is null) {
+            Logger.Error (Strings.TypeService.MappingNotFound (oldMapping.ClrType, oldMapping.ObjCType));
+            return false;
+        }
 
-	TypeMapping? UpdateMappingFromCompilation (TypeMapping oldMapping, Compilation compilation)
-	{
-		var namespaces = compilation!.GlobalNamespace.GetNamespaceMembers ()
-			.Where (ns => ns.GetMembers ()
-				.Any (member => member.Locations
-					.Any (location => location.IsInSource)));
+        if (clrTypes.TryUpdate (oldMapping.ClrType, newMapping, existingClrMapping)) {
+            if (!objCTypes.TryUpdate (oldMapping.ObjCType, newMapping, existingObjCMapping)) {
+                Logger.Error (Strings.TypeService.MappingUpdateFailed (oldMapping.ClrType, oldMapping.ObjCType));
+                clrTypes.TryUpdate (oldMapping.ClrType, existingClrMapping, newMapping);
+                return false;
+            }
+        };
+        return true;
+    }
 
-		var newMapping = compilation.GlobalNamespace.GetNamespaceMembers ()
-			.Where (ns => ns.GetMembers ()
-				.Any (member => member.Locations
-					.Any (location => location.IsInSource)))
-			.SelectMany (ns => ns.GetTypeMembers ())
-			.Where (type => xcSync.IsNsoDerived (type) && type.Name == oldMapping.ClrType)
-			.Select (type => oldMapping with { TypeSymbol = type, HasChanges = true })
-			.FirstOrDefault ();
+    TypeMapping? UpdateMappingFromCompilation (TypeMapping oldMapping, Compilation compilation)
+    {
+        var newMapping = GetAllNamespaces (compilation.GlobalNamespace)
+            .Where (ns => ns.GetMembers ()
+                .Any (member => member.Locations
+                    .Any (location => location.IsInSource)))
+            .SelectMany (ns => ns.GetTypeMembers ())
+            .Where (type => xcSync.IsNsoDerived (type) && type.Name == oldMapping.ClrType)
+            .Select (type => oldMapping with { TypeSymbol = type, HasChanges = true })
+            .FirstOrDefault ();
 
-		return newMapping;
-	}
+        return newMapping;
+    }
 
-	public virtual IEnumerable<TypeMapping?> QueryTypes (string? clrType = null, string? objcType = null) =>
-		(clrType, objcType) switch {
-			(string cli, null) => clrTypes.Values.Where (t => t?.ClrType == cli),
-			(null, string objc) => objCTypes.Values.Where (t => t?.ObjCType == objc),
-			(string clr, string objc) => clrTypes.Values.Where (t => t?.ClrType == clr && t.ObjCType == objc),
-			_ => clrTypes.Values
-		};
+    public virtual IEnumerable<TypeMapping?> QueryTypes (string? clrType = null, string? objcType = null) =>
+        (clrType, objcType) switch {
+            (string cli, null) => clrTypes.Values.Where (t => t?.ClrType == cli),
+            (null, string objc) => objCTypes.Values.Where (t => t?.ObjCType == objc),
+            (string clr, string objc) => clrTypes.Values.Where (t => t?.ClrType == clr && t.ObjCType == objc),
+            _ => clrTypes.Values
+        };
 
-	public void AddCompilation (string targetPlatform, Compilation compilation)
-	{
-		if (compilation.AssemblyName is null) {
-			Logger.Error (Strings.TypeService.MissingAssemblyName);
-			return;
-		}
+    public void AddCompilation (string targetPlatform, Compilation compilation)
+    {
+        if (compilation.AssemblyName is null) {
+            Logger.Error (Strings.TypeService.MissingAssemblyName);
+            return;
+        }
 
-		if (!compilations.TryAdd (compilation.AssemblyName, compilation)) {
-			Logger.Error (Strings.TypeService.DuplicateCompilation (compilation.AssemblyName), compilation.AssemblyName);
-		};
+        if (!compilations.TryAdd (compilation.AssemblyName, compilation)) {
+            Logger.Error (Strings.TypeService.DuplicateCompilation (compilation.AssemblyName), compilation.AssemblyName);
+        };
 
-		AddTypesFromCompilation (targetPlatform, compilation);
-	}
+        AddTypesFromCompilation (targetPlatform, compilation);
+    }
 
-	async Task<Compilation> UpdateCompilation (INamedTypeSymbol typeSymbol, SyntaxNode newSyntax)
-	{
-		if (!compilations.TryGetValue (typeSymbol.ContainingAssembly.Name, out var compilation)) {
-			Logger.Error (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
-			throw new InvalidOperationException (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
-		}
+    async Task<Compilation> UpdateCompilation (INamedTypeSymbol typeSymbol, SyntaxNode newSyntax)
+    {
+        if (!compilations.TryGetValue (typeSymbol.ContainingAssembly.Name, out var compilation)) {
+            Logger.Error (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
+            throw new InvalidOperationException (Strings.TypeService.CompilationNotFound (typeSymbol.ContainingAssembly.Name));
+        }
 
-		var root = await compilation.SyntaxTrees.First (st => st.FilePath == newSyntax.SyntaxTree.FilePath).GetRootAsync ();
-		if (root is null) {
-			Logger.Error (Strings.TypeService.SyntaxRootNotFound (typeSymbol.Name));
-			return compilation;
-		}
+        var root = await compilation.SyntaxTrees.First (st => st.FilePath == newSyntax.SyntaxTree.FilePath).GetRootAsync ();
+        if (root is null) {
+            Logger.Error (Strings.TypeService.SyntaxRootNotFound (typeSymbol.Name));
+            return compilation;
+        }
 
-		var newModel = compilation.ReplaceSyntaxTree (root.SyntaxTree, newSyntax.SyntaxTree);
+        var newModel = compilation.ReplaceSyntaxTree (root.SyntaxTree, newSyntax.SyntaxTree);
 
-		if (newModel.GetDiagnostics ().Any (diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)) {
-			Logger.Verbose (Strings.TypeService.CompilationErrorsFound (newModel.AssemblyName!));
-			foreach (var diagnostic in newModel.GetDiagnostics ()) {
-				if (diagnostic.Severity == DiagnosticSeverity.Error) {
-					Logger.Verbose (Strings.TypeService.AssemblyDiagnosticError (newModel.AssemblyName!, diagnostic.ToString ()));
-				}
-			}
-		}
+        if (newModel.GetDiagnostics ().Any (diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)) {
+            Logger.Verbose (Strings.TypeService.CompilationErrorsFound (newModel.AssemblyName!));
+            foreach (var diagnostic in newModel.GetDiagnostics ()) {
+                if (diagnostic.Severity == DiagnosticSeverity.Error) {
+                    Logger.Verbose (Strings.TypeService.AssemblyDiagnosticError (newModel.AssemblyName!, diagnostic.ToString ()));
+                }
+            }
+        }
 
-		if (newModel.AssemblyName is null) {
-			Logger.Error (Strings.TypeService.MissingAssemblyName);
-			return compilation;
-		}
+        if (newModel.AssemblyName is null) {
+            Logger.Error (Strings.TypeService.MissingAssemblyName);
+            return compilation;
+        }
 
-		if (!compilations.TryUpdate (newModel.AssemblyName, newModel, compilation))
-			Logger.Error (Strings.TypeService.AssemblyUpdateError (compilation.AssemblyName!));
+        if (!compilations.TryUpdate (newModel.AssemblyName, newModel, compilation))
+            Logger.Error (Strings.TypeService.AssemblyUpdateError (compilation.AssemblyName!));
 
-		return newModel;
-	}
+        return newModel;
+    }
 
-	void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
-	{
-		// limit scope of namespaces to only those that contain NSObject derived types.
-		var namespaces = compilation.GlobalNamespace.GetNamespaceMembers ()
-			.Where (ns => ns.GetTypeMembers ()
-				.Any (xcSync.IsNsoDerived));
+    void AddTypesFromCompilation (string targetPlatform, Compilation compilation)
+    {
+        // limit scope of namespaces to only those that contain NSObject derived types.
+        var namespaces = GetAllNamespaces (compilation.GlobalNamespace)
+            .Where (ns => ns.GetTypeMembers ()
+                .Any (xcSync.IsNsoDerived));
 
-		if (namespaces is null)
-			return;
+        if (namespaces is null)
+            return;
 
-		foreach (var ns in namespaces) {
-			foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
-				var nsType = ConvertToTypeMapping (targetPlatform, type);
-				if (nsType is not null) {
-					AddType (nsType with { IsInSource = type.Locations.Any (l => l.IsInSource) });
-				}
-			}
-		}
-	}
+        foreach (var ns in namespaces) {
+            foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
+                var nsType = ConvertToTypeMapping (targetPlatform, type);
+                if (nsType is not null) {
+                    AddType (nsType with { IsInSource = type.Locations.Any (l => l.IsInSource) });
+                }
+            }
+        }
+    }
 
-	TypeMapping? ConvertToTypeMapping (string targetPlatform, INamedTypeSymbol type)
-	{
-		// TypeMapping bridges the gap between the .net + objc worlds
-		// extracts the necessary info from the roslyn detected type for objc .h and .m file generation
-		// so this method is orchestrating the conversion of the roslyn type to TypeMapping
+    TypeMapping? ConvertToTypeMapping (string targetPlatform, INamedTypeSymbol type)
+    {
+        // TypeMapping bridges the gap between the .net + objc worlds
+        // extracts the necessary info from the roslyn detected type for objc .h and .m file generation
+        // so this method is orchestrating the conversion of the roslyn type to TypeMapping
 
-		// If the type is not a model, we handle the properties and methods for IBOutlets and IBActions handling too
-		var isModel = false;
-		var isProtocol = false;
-		var clrName = type.MetadataName;
-		var objCName = type.Name;
-		HashSet<string> refs = [];
+        // If the type is not a model, we handle the properties and methods for IBOutlets and IBActions handling too
+        var isModel = false;
+        var isProtocol = false;
+        var clrName = type.MetadataName;
+        var objCName = type.Name;
+        HashSet<string> refs = [];
 
-		if (clrTypes.TryGetValue (clrName, out var existingTypeMapping))
-			return existingTypeMapping;
+        if (clrTypes.TryGetValue (clrName, out var existingTypeMapping))
+            return existingTypeMapping;
 
-		var baseType = type.BaseType;
-		if (baseType is null) {
-			clrTypes [clrName] = null; // this saves computing the type multiple times and failing each type
-			return null;
-		}
+        var baseType = type.BaseType;
+        if (baseType is null) {
+            clrTypes [clrName] = null; // this saves computing the type multiple times and failing each type
+            return null;
+        }
 
-		var baseTypeMapping = ConvertToTypeMapping (targetPlatform, baseType);
+        var baseTypeMapping = ConvertToTypeMapping (targetPlatform, baseType);
 
-		foreach (var a in type.GetAttributes ()) {
-			switch (a.AttributeClass?.Name) {
-			case "ProtocolAttribute":
-				isProtocol = true;
-				break;
-			case "ModelAttribute":
-				isModel = true;
-				break;
-			case "RegisterAttribute":
-				objCName = a.ConstructorArguments.Length > 0
-					? GetName (a) ?? objCName
-					: objCName;
-				break;
-			}
-		}
+        foreach (var a in type.GetAttributes ()) {
+            switch (a.AttributeClass?.Name) {
+            case "ProtocolAttribute":
+                isProtocol = true;
+                break;
+            case "ModelAttribute":
+                isModel = true;
+                break;
+            case "RegisterAttribute":
+                objCName = a.ConstructorArguments.Length > 0
+                    ? GetName (a) ?? objCName
+                    : objCName;
+                break;
+            }
+        }
 
-		List<IBOutlet> outlets = [];
-		List<IBAction> actions = [];
+        List<IBOutlet> outlets = [];
+        List<IBAction> actions = [];
 
-		if (!isModel) {
+        if (!isModel) {
 
-			foreach (var property in type.GetMembers ().OfType<IPropertySymbol> ()) {
+            foreach (var property in type.GetMembers ().OfType<IPropertySymbol> ()) {
 
-				var outletAttribute = GetAttribute (property, "OutletAttribute");
+                var outletAttribute = GetAttribute (property, "OutletAttribute");
 
-				if (outletAttribute is null)
-					continue;
+                if (outletAttribute is null)
+                    continue;
 
-				outlets.Add (new IBOutlet (
-					clrName: property.Name,
-					objcName: GetName (outletAttribute) ?? property.Name,
-					clrType: property.Type.MetadataName,
-					objcType: GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type),
-					isCollection: property.Type.TypeKind == TypeKind.Array));
+                outlets.Add (new IBOutlet (
+                    clrName: property.Name,
+                    objcName: GetName (outletAttribute) ?? property.Name,
+                    clrType: property.Type.MetadataName,
+                    objcType: GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type),
+                    isCollection: property.Type.TypeKind == TypeKind.Array));
 
-				refs.Add (property.ContainingNamespace.Name);
-			}
+                refs.Add (property.ContainingNamespace.Name);
+            }
 
-			foreach (var method in type.GetMembers ().OfType<IMethodSymbol> ()) {
+            foreach (var method in type.GetMembers ().OfType<IMethodSymbol> ()) {
 
-				var actionAttribute = GetAttribute (method, "ActionAttribute");
+                var actionAttribute = GetAttribute (method, "ActionAttribute");
 
-				if (actionAttribute is null)
-					continue;
+                if (actionAttribute is null)
+                    continue;
 
-				var actionName = GetName (actionAttribute);
-				(string? objcName, string []? strings) = GetInfo (method, actionName);
+                var actionName = GetName (actionAttribute);
+                (string? objcName, string []? strings) = GetInfo (method, actionName);
 
-				List<IBActionParameter> parameters = new (method.Parameters.Length);
+                List<IBActionParameter> parameters = new (method.Parameters.Length);
 
-				var index = 0;
-				foreach (var param in method.Parameters) {
-					parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type)));
-					index++;
-					refs.Add (param.ContainingNamespace.Name);
-				}
+                var index = 0;
+                foreach (var param in method.Parameters) {
+                    parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type)));
+                    index++;
+                    refs.Add (param.ContainingNamespace.Name);
+                }
 
-				actions.Add (new IBAction (method.Name, objcName, parameters));
-			}
-		}
+                actions.Add (new IBAction (method.Name, objcName, parameters));
+            }
+        }
 
-		refs.Add (type.ContainingNamespace.Name);
+        refs.Add (type.ContainingNamespace.Name);
 
-		if (baseTypeMapping is not null)
-			refs.UnionWith (baseTypeMapping.References);
+        if (baseTypeMapping is not null)
+            refs.UnionWith (baseTypeMapping.References);
 
-		var typeMapping = new TypeMapping (type, clrName, objCName, baseTypeMapping, isModel, isProtocol, InDesignerFile (type, objCName),
-			outlets.Count == 0 ? null : outlets, actions.Count == 0 ? null : actions,
-			refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ());
+        var typeMapping = new TypeMapping (type, clrName, objCName, baseTypeMapping, isModel, isProtocol, InDesignerFile (type, objCName),
+            outlets.Count == 0 ? null : outlets, actions.Count == 0 ? null : actions,
+            refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ());
 
-		return typeMapping;
-	}
+        return typeMapping;
+    }
 
-	bool InDesignerFile (ITypeSymbol type, string objCName)
-	{
-		var source = type.Locations.FirstOrDefault ()?.SourceTree;
-		var sourceDir = FileSystem.Path.GetDirectoryName (source?.FilePath) ?? string.Empty;
-		return FileSystem.File.Exists (FileSystem.Path.Combine (sourceDir, $"{objCName}.designer.cs"));
-	}
+    bool InDesignerFile (ITypeSymbol type, string objCName)
+    {
+        var source = type.Locations.FirstOrDefault ()?.SourceTree;
+        var sourceDir = FileSystem.Path.GetDirectoryName (source?.FilePath) ?? string.Empty;
+        return FileSystem.File.Exists (FileSystem.Path.Combine (sourceDir, $"{objCName}.designer.cs"));
+    }
 
-	static AttributeData? GetAttribute (ISymbol symbol, string attributeName) =>
-		symbol.GetAttributes ().FirstOrDefault (a => a.AttributeClass?.Name == attributeName);
+    static AttributeData? GetAttribute (ISymbol symbol, string attributeName) =>
+        symbol.GetAttributes ().FirstOrDefault (a => a.AttributeClass?.Name == attributeName);
 
-	static string? GetName (AttributeData attribute) =>
-		attribute.ConstructorArguments.FirstOrDefault ().Value?.ToString ();
+    static string? GetName (AttributeData attribute) =>
+        attribute.ConstructorArguments.FirstOrDefault ().Value?.ToString ();
 
-	string? GetObjCType (string targetPlatform, INamedTypeSymbol symbol)
-	{
-		clrTypes.TryGetValue (symbol.MetadataName, out var nsType);
-		return nsType?.ObjCType ?? ConvertToTypeMapping (targetPlatform, symbol)?.ObjCType;
-	}
+    string? GetObjCType (string targetPlatform, INamedTypeSymbol symbol)
+    {
+        clrTypes.TryGetValue (symbol.MetadataName, out var nsType);
+        return nsType?.ObjCType ?? ConvertToTypeMapping (targetPlatform, symbol)?.ObjCType;
+    }
 
-	static (string objcName, string []? @params) GetInfo (IMethodSymbol method, string? actionAttributeName)
-	{
-		if (actionAttributeName is null)
-			return (method.Name, null);
-		var split = actionAttributeName.Split (":", StringSplitOptions.TrimEntries);
-		return split.Length > 1 ? (split [0], split [1..]) : (split [0], null);
-	}
+    static (string objcName, string []? @params) GetInfo (IMethodSymbol method, string? actionAttributeName)
+    {
+        if (actionAttributeName is null)
+            return (method.Name, null);
+        var split = actionAttributeName.Split (":", StringSplitOptions.TrimEntries);
+        return split.Length > 1 ? (split [0], split [1..]) : (split [0], null);
+    }
 
 }

--- a/test/xcsync.tests/Base.cs
+++ b/test/xcsync.tests/Base.cs
@@ -3,8 +3,10 @@
 
 using System.CommandLine;
 using System.CommandLine.IO;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using Serilog;
 using Serilog.Events;
 using Xamarin.Utils;
@@ -47,7 +49,31 @@ public class Base : IDisposable {
 		Assert.Equal (0, exec.ExitCode);
 	}
 
-	protected static async Task DotnetNew (ITestOutputHelper output, string template, string path, string templateOptions = "") => await Run (output, path, DotNetExe, "new", template, "-o", path, templateOptions);
+	protected static async Task DotnetNew (ITestOutputHelper output, string template, string path, string templateOptions = "", string targetFramework = "net8.0")
+	{
+		await Run (output, path, DotNetExe, "new", template, "-o", path, templateOptions);
+
+		await PatchProjectsTfmsAsync (path, targetFramework);
+	}
+
+	private static async Task PatchProjectsTfmsAsync (string path, string targetFramework)
+	{
+		// Patch the TargetFramework(s) in all project files
+		foreach (var projFile in Directory.GetFiles (path, "*.*proj", SearchOption.AllDirectories)) {
+			var content = await File.ReadAllTextAsync (projFile);
+			// Replace <TargetFramework>netX.Y[-suffix]</TargetFramework>
+			content = Regex.Replace (
+				content,
+				@"(<TargetFramework>)net\d+\.\d+(-[^<]*)?(<\/TargetFramework>)",
+				$"${{1}}{targetFramework}$2${{3}}");
+			// Replace each TFM in <TargetFrameworks>netX.Y[-suffix];netX.Y[-suffix]</TargetFrameworks>
+			content = Regex.Replace (
+				content,
+				@"(?<=<TargetFrameworks>[^<]*)net\d+\.\d+(?=-[^;<]*|[;<])",
+				targetFramework);
+			await File.WriteAllTextAsync (projFile, content);
+		}
+	}
 
 	public void Dispose ()
 	{

--- a/test/xcsync.tests/Base.cs
+++ b/test/xcsync.tests/Base.cs
@@ -52,11 +52,12 @@ public class Base : IDisposable {
 	protected static async Task DotnetNew (ITestOutputHelper output, string template, string path, string templateOptions = "", string targetFramework = "net8.0")
 	{
 		await Run (output, path, DotNetExe, "new", template, "-o", path, templateOptions);
-
+		// Templates may upgrade and change the project's target framework (TFM).
+		// Normalize it here to the version expected by our tests (currently .NET 8.0).
 		await PatchProjectsTfmsAsync (path, targetFramework);
 	}
 
-	private static async Task PatchProjectsTfmsAsync (string path, string targetFramework)
+	static async Task PatchProjectsTfmsAsync (string path, string targetFramework)
 	{
 		// Patch the TargetFramework(s) in all project files
 		foreach (var projFile in Directory.GetFiles (path, "*.*proj", SearchOption.AllDirectories)) {

--- a/test/xcsync.tests/Commands/CommandValidationTests.cs
+++ b/test/xcsync.tests/Commands/CommandValidationTests.cs
@@ -102,7 +102,11 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 	[InlineData ("maui", "net8.0-maccatalyst", "{IntermediateOutputPath}/xcsync", "")]
 	[InlineData ("maui", "net8.0-macos", "obj/xcsync", "Target framework is not supported by current .NET project.")]
 	[InlineData ("maui", "net8.0-ios", "{Directory}/xcode{DoesNotExist}", "Target path '{TargetPath}' does not exist, or is not a valid Xcode project folder.")]
-	public async void BaseCommandValidation_SingleProject (string projectType, string tfm, string targetPath, string expectedError)
+	public async void BaseCommandValidation_SingleProject (
+		string projectType,
+		string tfm,
+		string targetPath,
+		string expectedError)
 	{
 		var createXcodeProject = !targetPath.Contains ("{DoesNotExist}");
 		var projectName = Guid.NewGuid ().ToString ();

--- a/test/xcsync.tests/Projects/TypeServiceTest.cs
+++ b/test/xcsync.tests/Projects/TypeServiceTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Moq;
 using Serilog;
 using xcsync.Projects;
@@ -69,5 +71,130 @@ public class TypeServiceTest {
 		typeService.AddType (appDelegateDupe);
 		var result = typeService.AddType (appDelegateDupe);
 		Assert.Null (result);
+	}
+
+	[Fact]
+	public void AddCompilation_FindsTypesInNestedNamespaces ()
+	{
+		var compilation = CreateCompilation (
+			"""
+			using System;
+
+			namespace Foundation {
+				[AttributeUsage (AttributeTargets.Class)]
+				public sealed class RegisterAttribute : Attribute {
+				}
+
+				[Register]
+				public class NSObject {
+				}
+			}
+
+			namespace AppKit {
+				[Foundation.Register]
+				public class NSViewController : Foundation.NSObject {
+				}
+			}
+
+			namespace TestProject.Controllers.Nested {
+				[Foundation.Register]
+				public class NestedViewController : AppKit.NSViewController {
+				}
+			}
+			""");
+
+		typeService.AddCompilation ("macos", compilation);
+
+		var result = Assert.Single (typeService.QueryTypes (clrType: "NestedViewController"));
+		Assert.NotNull (result);
+		Assert.True (result.IsInSource);
+		Assert.Equal ("NestedViewController", result.ObjCType);
+		Assert.Equal ("NSViewController", result.BaseType?.ClrType);
+	}
+
+	[Fact]
+	public async Task TryUpdateMappingAsync_FindsTypesInNestedNamespaces ()
+	{
+		var source =
+			"""
+			using System;
+
+			namespace Foundation {
+				[AttributeUsage (AttributeTargets.Class)]
+				public sealed class RegisterAttribute : Attribute {
+				}
+
+				[Register]
+				public class NSObject {
+				}
+			}
+
+			namespace AppKit {
+				[Foundation.Register]
+				public class NSViewController : Foundation.NSObject {
+				}
+			}
+
+			namespace TestProject.Controllers.Nested {
+				[Foundation.Register]
+				public class NestedViewController : AppKit.NSViewController {
+				}
+			}
+			""";
+		var updatedSource =
+			"""
+			using System;
+
+			namespace Foundation {
+				[AttributeUsage (AttributeTargets.Class)]
+				public sealed class RegisterAttribute : Attribute {
+				}
+
+				[Register]
+				public class NSObject {
+				}
+			}
+
+			namespace AppKit {
+				[Foundation.Register]
+				public class NSViewController : Foundation.NSObject {
+				}
+			}
+
+			namespace TestProject.Controllers.Nested {
+				[Foundation.Register]
+				public class NestedViewController : AppKit.NSViewController {
+					public int Value => 1;
+				}
+			}
+			""";
+		var compilation = CreateCompilation (source);
+		typeService.AddCompilation ("macos", compilation);
+
+		var existingMapping = Assert.Single (typeService.QueryTypes (clrType: "NestedViewController"));
+		Assert.NotNull (existingMapping);
+
+		var updatedTree = CSharpSyntaxTree.ParseText (updatedSource, path: "NestedViewController.cs");
+		var updatedRoot = await updatedTree.GetRootAsync ();
+		var updatedType = updatedRoot.DescendantNodes ().OfType<ClassDeclarationSyntax> ()
+			.Single (node => node.Identifier.ValueText == "NestedViewController");
+
+		var result = await typeService.TryUpdateMappingAsync (existingMapping, updatedType);
+
+		Assert.True (result);
+		Assert.True (Assert.Single (typeService.QueryTypes (clrType: "NestedViewController"))?.HasChanges);
+	}
+
+	static Compilation CreateCompilation (string source)
+	{
+		var syntaxTree = CSharpSyntaxTree.ParseText (source, path: "NestedViewController.cs");
+
+		return CSharpCompilation.Create (
+			"NestedNamespaceTests",
+			[syntaxTree],
+			[
+				MetadataReference.CreateFromFile (typeof (object).Assembly.Location),
+			],
+			new CSharpCompilationOptions (OutputKind.DynamicallyLinkedLibrary));
 	}
 }


### PR DESCRIPTION
This solve issue #183. 

To replicate the issue it's enough to do this: 
```
dotnet new macos -n Namespace.With.Dot
cd Namespace.With.Dot
xcsync generate
```
while this works:
```
dotnet new macos -n SimpleNamespace
cd SimpleNamespace
xcsync generate
```

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/240)