### PR TITLE
Adds an --incremental (-i) option to the xcsync watch command.

### DIFF
--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -12,12 +12,23 @@ namespace xcsync.Commands;
 
 class WatchCommand : XcodeCommand<WatchCommand> {
 
+	protected Option<bool> incremental = new (
+		["--incremental", "-i"],
+		description: Strings.Options.IncrementalDescription,
+		getDefaultValue: () => false);
+
 	public WatchCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "watch", Strings.Commands.WatchDescription)
 	{
-		this.SetHandler (Execute, project, target, tfm, force, open);
+		this.SetHandler (Execute, project, target, tfm, force, open, incremental);
 	}
 
-	public async Task Execute (string project, string target, string tfm, bool force, bool open)
+	protected override void AddOptions ()
+	{
+		base.AddOptions ();
+		Add (incremental);
+	}
+
+	public async Task Execute (string project, string target, string tfm, bool force, bool open, bool incremental)
 	{
 		using var cts = new CancellationTokenSource ();
 
@@ -31,7 +42,7 @@ class WatchCommand : XcodeCommand<WatchCommand> {
 
 		LogInformation (Strings.Watch.HeaderInformation (ProjectPath, TargetPath, Tfm));
 
-		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, open, force);
+		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, open, force, incremental);
 
 		// Start an asynchronous task
 		var xcsyncTask = Task.Run (async () => {

--- a/src/xcsync/ContinuousSyncContext.cs
+++ b/src/xcsync/ContinuousSyncContext.cs
@@ -8,7 +8,7 @@ using xcsync.Projects;
 
 namespace xcsync;
 
-class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false)
+class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false, bool incremental = false)
 	: SyncContextBase (fileSystem, typeService, projectPath, targetDir, framework, logger) {
 
 	public const string ChangeChannel = "Changes";
@@ -33,14 +33,14 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.ToXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.ToXcode, clrChanges, xcodeChanges, incremental));
 		};
 
 		xcodeChanges.OnFileChanged = async path => {
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.FromXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.FromXcode, clrChanges, xcodeChanges, incremental));
 		};
 
 		async void ClrFileRenamed (string oldPath, string newPath)
@@ -48,7 +48,7 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.ToXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.ToXcode, clrChanges, xcodeChanges, incremental));
 		}
 
 		clrChanges.OnFileRenamed = ClrFileRenamed;
@@ -58,7 +58,7 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.FromXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.FromXcode, clrChanges, xcodeChanges, incremental));
 		}
 
 		xcodeChanges.OnFileRenamed = XcodeFileRenamed;

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -18,6 +18,7 @@ static class Strings {
 		internal static string TfmDescription => Resources.Strings.Options_Tfm_Description;
 		internal static string VerbosityDescription => Resources.Strings.Options_Verbosity_Description;
 		internal static string DotnetPathDescription => Resources.Strings.Options_DotnetPath_Description;
+		internal static string IncrementalDescription => Resources.Strings.Options_Incremental_Description;
 	}
 
 	internal static class Commands {
@@ -88,6 +89,7 @@ static class Strings {
 		internal static string ResumingMonitoring => Resources.Strings.Watch_ResumingMonitoring;
 		internal static string WorkerException (string messageId, string exceptionMessage) => string.Format (Resources.Strings.Watch_WorkerException, messageId, exceptionMessage);
 		internal static string StopWatchProcess => Resources.Strings.Watch_StopWatchProcess;
+		internal static string IncrementalSyncing (string path) => string.Format (Resources.Strings.Watch_IncrementalSyncing, path);
 	}
 
 	internal static class TypeService {

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -152,6 +152,10 @@
 		<value>Set the path to the .NET SDK, when not provided will use the path from the parent process if it is 'dotnet' otherwise falls back to the 'dotnet' on the PATH.</value>
 	</data>
 
+	<data name="Options.Incremental.Description" xml:space="preserve">
+		<value>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</value>
+	</data>
+
 	<!-- Commands -->
 	<data name="Commands.Generate.Description" xml:space="preserve">
 		<value>generate a Xcode project at the path specified by --target from the project identified by --project</value>
@@ -341,6 +345,10 @@
 	</data>
 	<data name="Watch.StopWatchProcess" xml:space="preserve">
 		<value>User has requested to stop the sync process. Changes will no longer be processed.</value>
+	</data>
+	<data name="Watch.IncrementalSyncing" xml:space="preserve">
+		<value>Incrementally syncing changes related to '{0}'</value>
+		<comment>{0} is the path of the changed file</comment>
 	</data>
 
     <!-- Type Service Messages -->

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Vynutit přepsání existujícího projektu Xcode</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Otevřít vygenerovaný projekt v Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Průběžná synchronizace souborů mezi {0} a {1} pro platformu {2}</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Überschreiben eines vorhandenen Xcode-Projekts erzwingen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Generiertes Projekt in Xcode öffnen</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Fortlaufendes Synchronisieren von Dateien zwischen „{0}“ und „{1}“ für die Plattform „{2}“</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Forzar la sobreescritura de un proyecto de Xcode existente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Abrir el proyecto generado en Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizando archivos continuamente entre "{0}" y "{1}" para la plataforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Forcer le remplacement d’un projet Xcode existant</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Ouvrir le projet généré dans Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Synchronisation continue des fichiers entre « {0} » et « {1} » pour la plateforme « {2} ».</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Forza sovrascrittura di un progetto Xcode esistente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Apri il progetto generato in Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizzazione continua dei file tra "{0}" e "{1}" per la piattaforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -237,6 +237,11 @@
         <target state="translated">既存の Xcode プロジェクトを強制的に上書きする</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Xcode で生成されたプロジェクトを開く</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' プラットフォームの '{0}' と '{1}' の間でファイルを継続的に同期しています。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -237,6 +237,11 @@
         <target state="translated">기존 Xcode 프로젝트 강제 덮어쓰기</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">생성된 프로젝트를 Xcode에서 엽니다.</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' 플랫폼에 대해 '{0}'에서 '{1}'(으)로 파일을 지속적으로 동기화합니다.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Wymuś zastąpienie istniejącego projektu Xcode</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Otwieranie wygenerowanego projektu w środowisku Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Ciągła synchronizacja plików między platformą „{0}” i „{1}” dla platformy „{2}”.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Forçar a substituição de um projeto Xcode existente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Abrir o projeto gerado no Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizando continuamente arquivos entre "{0}" e "{1}" para a plataforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Принудительная перезапись существующего проекта Xcode</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Открыть созданный проект в Xcode</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Непрерывная синхронизация файлов между "{0}" и "{1}" для платформы "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -237,6 +237,11 @@
         <target state="translated">Mevcut bir Xcode projesinin üzerine yazmaya zorla</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">Oluşturulan projeyi Xcode'da aç</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' platformu için '{0}' ve '{1}' arasındaki dosyalar sürekli eşitleniyor.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -237,6 +237,11 @@
         <target state="translated">强制覆盖现有 Xcode 项目</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">在 Xcode 中打开生成的项目</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">持续在 "{0}" 和 "{1}" 之间为“{2}”平台同步文件。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -237,6 +237,11 @@
         <target state="translated">強制覆寫現有的 Xcode 專案</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Open.Description">
         <source>Open the generated project in Xcode</source>
         <target state="translated">在 Xcode 中開啟產生的專案</target>
@@ -373,6 +378,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">在 '{2}' 平台持續同步 '{0}' 和 '{1}' 之間的檔案。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -11,7 +11,7 @@ using xcsync.Workers;
 
 namespace xcsync;
 
-class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirection Direction, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false)
+class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirection Direction, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false, string? changedFilePath = null)
 	: SyncContextBase (fileSystem, typeService, projectPath, targetDir, framework, logger) {
 
 	public const string FileChannel = "Files";
@@ -124,7 +124,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		};
 		xcodeObjects.Add (pbxGroup.Token, pbxGroup);
 
-		foreach (var t in TypeService.QueryTypes ().Where (t => t is not null && t.IsInSource)) {
+		foreach (var t in TypeService.QueryTypes ().Where (t => t is not null && t.IsInSource && (changedFilePath is null || t.TypeSymbol?.Locations.Any (l => l.SourceTree?.FilePath == changedFilePath) == true))) {
 
 			if (t is null) continue; // Only needed to keep the compiler happy
 
@@ -148,6 +148,12 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		Logger?.Debug (Strings.Generate.GeneratedFiles);
+
+		if (changedFilePath is not null) {
+			// For incremental sync, only the source files need to be regenerated.
+			// Resources and the Xcode project structure are not affected.
+			return;
+		}
 
 		// leverage msbuild to get the list of files in the project
 		var filePaths = Scripts.GetFileItemsFromProject (ProjectPath, Framework.Platform, targetPlatform);
@@ -494,7 +500,16 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		List<Task> tasks = [];
-		foreach (var syncItem in xcodeWorkspace.Items) {
+		IEnumerable<ISyncableItem> itemsToProcess = xcodeWorkspace.Items;
+		if (changedFilePath is not null) {
+			var changedFileBaseName = FileSystem.Path.GetFileNameWithoutExtension (changedFilePath);
+			itemsToProcess = itemsToProcess.Where (item => item switch {
+				SyncableType type => FileSystem.Path.GetFileNameWithoutExtension (type.FilePath) == changedFileBaseName,
+				SyncableContent content => content.SourcePath == changedFilePath,
+				_ => false
+			});
+		}
+		foreach (var syncItem in itemsToProcess) {
 			var basePath = string.Empty;
 			if (syncItem is SyncableContent content && (
 				content.SourcePath.EndsWith (".xcassets", StringComparison.OrdinalIgnoreCase) ||
@@ -519,6 +534,11 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 
 		var typesToWrite = TypeService.QueryTypes (null, null) // All Types
 			.Where (t => t is not null && t.InDesigner) ?? []; // Filter Types that are in .designer.cs files TODO: This may be wrong, there are types that don't exist in *.designer.cs files
+
+		if (changedFilePath is not null) {
+			var changedFileBaseName = FileSystem.Path.GetFileNameWithoutExtension (changedFilePath);
+			typesToWrite = typesToWrite.Where (t => t?.ObjCType == changedFileBaseName);
+		}
 
 		// TODO: What happens when a new type is added to the Xcode project, like new view controllers?
 

--- a/src/xcsync/Workers/ChangeWorker.cs
+++ b/src/xcsync/Workers/ChangeWorker.cs
@@ -8,7 +8,7 @@ using xcsync.Workers;
 
 namespace xcsync;
 
-record struct ChangeMessage (string Id, string Path, SyncDirection Direction, ProjectFileChangeMonitor ClrMonitor, ProjectFileChangeMonitor XcodeMonitor);
+record struct ChangeMessage (string Id, string Path, SyncDirection Direction, ProjectFileChangeMonitor ClrMonitor, ProjectFileChangeMonitor XcodeMonitor, bool Incremental = false);
 
 class ChangeWorker (IFileSystem FileSystem, string ProjectPath, string TargetDir, string Framework, ILogger Logger, ClrProject ClrProject, XcodeWorkspace XcodeProject) : BaseWorker<ChangeMessage> {
 	public override async Task ConsumeAsync (ChangeMessage message, CancellationToken cancellationToken = default)
@@ -17,7 +17,10 @@ class ChangeWorker (IFileSystem FileSystem, string ProjectPath, string TargetDir
 		message.ClrMonitor.StopMonitoring ();
 		message.XcodeMonitor.StopMonitoring ();
 		Logger.Debug (Strings.Watch.Syncing);
-		await new SyncContext (FileSystem, new TypeService (Logger), message.Direction, ProjectPath, TargetDir, Framework, Logger, open: false, force: message.Direction == SyncDirection.ToXcode).SyncAsync (cancellationToken);
+		var changedFilePath = message.Incremental ? message.Path : null;
+		if (changedFilePath is not null)
+			Logger.Debug (Strings.Watch.IncrementalSyncing (changedFilePath));
+		await new SyncContext (FileSystem, new TypeService (Logger), message.Direction, ProjectPath, TargetDir, Framework, Logger, open: false, force: changedFilePath is null && message.Direction == SyncDirection.ToXcode, changedFilePath: changedFilePath).SyncAsync (cancellationToken);
 		Logger.Debug (Strings.Watch.ResumingMonitoring);
 		message.ClrMonitor.StartMonitoring (ClrProject, cancellationToken);
 		message.XcodeMonitor.StartMonitoring (XcodeProject, cancellationToken);

--- a/test/xcsync.tests/Commands/WatchCommandTests.cs
+++ b/test/xcsync.tests/Commands/WatchCommandTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.IO.Abstractions.TestingHelpers;
+using Moq;
+using Serilog;
+using xcsync.Commands;
+
+namespace xcsync.tests.Commands;
+
+public class WatchCommandTests {
+
+	[Fact]
+	public void WatchCommand_AddsIncrementalOption_WithDefaultFalse ()
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var incremental = GetIncrementalOption (command);
+		var parseResult = command.Parse ([]);
+
+		Assert.Equal (Strings.Options.IncrementalDescription, incremental.Description);
+		Assert.Contains ("-i", incremental.Aliases);
+		Assert.False (parseResult.CommandResult.GetValueForOption (incremental));
+	}
+
+	[Theory]
+	[InlineData ("--incremental")]
+	[InlineData ("-i")]
+	public void WatchCommand_ParsesIncrementalAliases (string alias)
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var incremental = GetIncrementalOption (command);
+		var parseResult = command.Parse ([alias]);
+
+		Assert.True (parseResult.CommandResult.GetValueForOption (incremental));
+	}
+
+	static Option<bool> GetIncrementalOption (WatchCommand command) =>
+		Assert.IsType<Option<bool>> (Assert.Single (command.Options.Where (option => option.Aliases.Contains ("--incremental"))));
+}

--- a/test/xcsync.tests/ContinuousSyncContextTest.cs
+++ b/test/xcsync.tests/ContinuousSyncContextTest.cs
@@ -2,16 +2,30 @@
 // Licensed under the MIT License.
 
 using System.IO.Abstractions;
-using Marille;
+using System.IO.Abstractions.TestingHelpers;
 using Moq;
 using Serilog;
-using xcsync.Projects;
-using xcsync.Workers;
 
 namespace xcsync.tests;
 
 public class ContinuousSyncContextTest {
-	readonly Mock<IHub> mockHub = new ();
-	readonly ContinuousSyncContext context = new (Mock.Of<IFileSystem> (), Mock.Of<ITypeService> (), "projectPath",
-		"targetDir", "framework", Mock.Of<ILogger> ());
+
+	[Fact]
+	public void ChangeMessage_DefaultsIncrementalToFalse ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.ToXcode, CreateMonitor (), CreateMonitor ());
+
+		Assert.False (message.Incremental);
+	}
+
+	[Fact]
+	public void ChangeMessage_CanEnableIncremental ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.ToXcode, CreateMonitor (), CreateMonitor (), true);
+
+		Assert.True (message.Incremental);
+	}
+
+	static ProjectFileChangeMonitor CreateMonitor () =>
+		new (new MockFileSystem (), Mock.Of<IFileSystemWatcher> (), Mock.Of<ILogger> ());
 }


### PR DESCRIPTION
### Summary
Adds an --incremental (-i) option to the xcsync watch command.

When enabled, watch mode syncs only the files related to the changed source/Xcode file instead of re-running a full project sync on every change.

### Why
Today, xcsync watch performs a full synchronization whenever a file changes. That is more work than necessary for small edits and makes watch mode slower and noisier during normal development.

This change introduces an incremental mode so watch can react more efficiently to single-file changes while preserving the existing full-sync behavior by default.

The xsync was unusable in my environment because if I change something in XCode, it takes around 1 minute to propagate the change to C# codebase. I have there around 30 items in XCode. With incremental option, it's within a few seconds.

### What changed
Added --incremental / -i to xcsync watch
Threaded the option through watch execution into change handling
Updated change messages to carry whether the sync should be incremental
Passed the changed file path into sync so only affected types/files are processed
Kept default behavior unchanged when the option is not specified
Result
With xcsync watch --incremental, edits in watch mode trigger a targeted sync for the changed file instead of syncing the entire project.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/241)