### PR TITLE
Github 242 - Fix missing import in generated .h and correct ns in designer.cs

### DIFF
--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -14,6 +14,7 @@ using xcsync.Projects;
 using static ClangSharp.Interop.CX_DeclKind;
 using static ClangSharp.Interop.CXTypeKind;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+using Newtonsoft.Json.Linq;
 
 namespace xcsync.Ast;
 
@@ -134,29 +135,33 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 
 		void Write (ObjCPropertyDecl objcProperty)
 		{
-			if (objcProperty.Attrs.ToList ().FirstOrDefault (a => a.Kind == CX_AttrKind.CX_AttrKind_IBOutlet) is null)
+			string propertyName = objcProperty.Name;
+			string propertyTypeObjC = string.Empty;			
+			if (objcProperty.Attrs.ToList ().FirstOrDefault (a => a.Kind == CX_AttrKind.CX_AttrKind_IBOutlet) is not null) {
+				propertyTypeObjC = GetObjCTypeName (objcProperty.Type.AsString)!;
+			}
+			// Determine the Objective-C type for the property.
+			// If the property has the IBOutlet attribute, we can get its type directly.
+			// Note: Some properties may not have the IBOutlet attribute (e.g., due to a missing import in the .h file).
+			// In such cases, attempt to parse the type manually from the header file. This can occur when wiring
+			// UI components in Xcode, XCode then doesn't add the import command.
+			else if (!TryGetOutletPropertyTypeFromSource(objcProperty, out propertyTypeObjC)) {
 				return;
+			}
+
+			if(objcProperty.Type.Kind != CXType_ObjCObjectPointer && objcProperty.Type.Kind != CXType_Pointer) {
+				throw new NotImplementedException (Strings.ObjCSyntax.PropertyNotImplementedException (objcProperty.Type.KindSpelling));
+			}
 
 			var root = (CompilationUnitSyntax) SyntaxTree!.GetRoot ();
-
 			var firstClass = root.DescendantNodes ().OfType<ClassDeclarationSyntax> ().First ();
 
-			var propertyName = objcProperty.Name;
-
 			logger.Debug (Strings.ObjCSyntax.ParsingProperty (nameof (ObjCSyntaxRewriter), objcProperty.Type.AsString));
-			// TODO: This is a *very* primitive way to get the property type and will need improvement
-			// TODO: Need a solution to handle the case where the property type is not found  or is null in the type mapping
-			var propertyType = objcProperty.Type switch {
-				{ Kind: CXType_ObjCObjectPointer } => GetPropertyTypeNameSafe (
-					typeService,
-					objcProperty,
-					firstClass),
-				_ => throw new NotImplementedException (
-					Strings.ObjCSyntax.PropertyNotImplementedException (objcProperty.Type.KindSpelling))
-			};
+
+			var mappedType = MapObjectCType (propertyTypeObjC, firstClass);
 
 			// Create the property
-			var property = PropertyDeclaration (ParseTypeName (propertyType), propertyName)
+			var property = PropertyDeclaration (ParseTypeName (mappedType), propertyName)
 				// .AddModifiers (Token (SyntaxKind.PublicKeyword))
 				.AddAccessorListAccessors (
 					AccessorDeclaration (SyntaxKind.GetAccessorDeclaration)
@@ -188,37 +193,13 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			SyntaxTree = newRoot.SyntaxTree;
 		}
 
-		string GetPropertyTypeNameSafe (
-			ITypeService typeService,
-			ObjCPropertyDecl objcProperty,
-			ClassDeclarationSyntax classDeclaration)
+		string MapObjectCType (string type, ClassDeclarationSyntax classDeclaration)
 		{
-			try {
-				// Attempt to resolve the type mapping from the ObjC type string.
-				var typeMapping = typeService
-					.QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
-					.FirstOrDefault ();
-							
-				if (typeMapping is null) {
-					logger.Error (
-						Strings.ObjCSyntax.TypeMappingNotFound (objcProperty.Type.AsString, objcProperty.Type.KindSpelling));
-
-					return string.Empty;
-				}
-				return GetPropertyTypeName (typeMapping, classDeclaration);
-			} catch (Exception ex) {
-				// Catch any unexpected errors during type resolution.
-				// We do NOT rethrow to avoid breaking existing behavior.
-				logger.Error (
-					ex,
-					Strings.ObjCSyntax.PropertyTypeResolutionFailed (objcProperty.Type.AsString, objcProperty.Type.KindSpelling));
-
-				return string.Empty; // fallback
+			var typeMapping = typeService.QueryTypes (null, type).FirstOrDefault ();
+			if(typeMapping is null) {
+				return "Foundation.NSObject";
 			}
-		}
 
-		static string GetPropertyTypeName (TypeMapping typeMapping, ClassDeclarationSyntax classDeclaration)
-		{
 			// This method converts a TypeMapping into a usable CLR type name,
 			// taking namespaces into account to avoid ambiguity.
 
@@ -286,28 +267,45 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 				return "Foundation.NSObject";
 
 			var objcTypeName = actionParameterType.Split (' ') [0];
-			var typeMapping = typeService.QueryTypes (null, objcTypeName).FirstOrDefault ();
+			return MapObjectCType (objcTypeName, classDeclaration);
+		}
 
-			return typeMapping is null
-				? "Foundation.NSObject"
-				: GetPropertyTypeName (typeMapping, classDeclaration);
+		static string? GetObjCTypeName (string? objcType)
+		{
+			if (string.IsNullOrWhiteSpace (objcType))
+				return null;
+
+			var match = Regex.Match (objcType, @"(?<type>[A-Za-z_]\w*)");
+			return match.Success ? match.Groups ["type"].Value : null;
+		}
+
+		static string? GetSourceContent (CXSourceRange sourceRange)
+		{
+			sourceRange.Start.GetFileLocation (out var file, out _, out _, out var start);
+			sourceRange.End.GetFileLocation (out _, out _, out _, out var end);
+
+			var fileContent = FileSystem.File.ReadAllText (file.Name.CString);
+
+			return fileContent.Substring ((int) start, (int) (end - start)).Trim ();
+		}
+
+		static bool TryGetOutletPropertyTypeFromSource (ObjCPropertyDecl objcProperty, out string type)
+		{
+			type = string.Empty;
+			var source = GetSourceContent (objcProperty.Extent);
+			if (!string.IsNullOrEmpty (source)) {
+				var match = Regex.Match (source, $@"IBOutlet\s*(?<type>\w*)\s*\*\s*{Regex.Escape (objcProperty.Name)}", RegexOptions.IgnoreCase);
+				type = match.Success ? match.Groups ["type"].Value.Trim () : string.Empty;
+			}
+			return !string.IsNullOrEmpty(type);
 		}
 
 		static string? TryGetActionParameterTypeFromSource (ObjCMethodDecl objcMethod)
 		{
-			objcMethod.Extent.Start.GetFileLocation (out var file, out uint line, out _, out _);
-			var fileName = file.Name.CString;
-			if (string.IsNullOrEmpty (fileName) || !FileSystem.File.Exists (fileName))
+			var source = GetSourceContent (objcMethod.Extent);
+			if (string.IsNullOrEmpty (source))
 				return null;
 
-			objcMethod.Extent.End.GetFileLocation (out _, out uint endLine, out _, out _);
-			var lines = FileSystem.File.ReadAllLines (fileName);
-			var startLine = (int) line;
-			var lastLine = Math.Min ((int) endLine, lines.Length);
-			if (startLine < 1 || startLine > lastLine)
-				return null;
-
-			var source = string.Join ("\n", lines [(startLine - 1)..lastLine]);
 			var match = Regex.Match (source, @":\(([^)]+)\)\s*\w+");
 
 			return match.Success ? match.Groups [1].Value.Trim () : null;

--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -93,7 +93,8 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 				Write (objcMethod!);
 				break;
 
-			};
+			}
+			;
 			return Task.CompletedTask;
 		}
 
@@ -142,10 +143,13 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			logger.Debug (Strings.ObjCSyntax.ParsingProperty (nameof (ObjCSyntaxRewriter), objcProperty.Type.AsString));
 			// TODO: This is a *very* primitive way to get the property type and will need improvement
 			// TODO: Need a solution to handle the case where the property type is not found  or is null in the type mapping
-			var propertyType = objcProperty.Type switch { { Kind: CXType_ObjCObjectPointer } => typeService
-															  .QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
-															  .First ()?.ClrType ?? string.Empty,
-				_ => throw new NotImplementedException (Strings.ObjCSyntax.PropertyNotImplementedException (objcProperty.Type.KindSpelling))
+			var propertyType = objcProperty.Type switch {
+				{ Kind: CXType_ObjCObjectPointer } => GetPropertyTypeNameSafe (
+					typeService,
+					objcProperty,
+					firstClass),
+				_ => throw new NotImplementedException (
+					Strings.ObjCSyntax.PropertyNotImplementedException (objcProperty.Type.KindSpelling))
 			};
 
 			// Create the property
@@ -179,6 +183,55 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			var newRoot = root.ReplaceNode (firstClass, newClass);
 
 			SyntaxTree = newRoot.SyntaxTree;
+		}
+
+		string GetPropertyTypeNameSafe (
+			ITypeService typeService,
+			ObjCPropertyDecl objcProperty,
+			ClassDeclarationSyntax classDeclaration)
+		{
+			try {
+				// Attempt to resolve the type mapping from the ObjC type string.
+				var typeMapping = typeService
+					.QueryTypes (null, objcProperty.Type.AsString.Split (' ') [0])
+					.FirstOrDefault ();
+							
+				if (typeMapping is null) {
+					logger.Error (
+						Strings.ObjCSyntax.TypeMappingNotFound (objcProperty.Type.AsString, objcProperty.Type.KindSpelling));
+
+					return string.Empty;
+				}
+				return GetPropertyTypeName (typeMapping, classDeclaration);
+			} catch (Exception ex) {
+				// Catch any unexpected errors during type resolution.
+				// We do NOT rethrow to avoid breaking existing behavior.
+				logger.Error (
+					ex,
+					Strings.ObjCSyntax.PropertyTypeResolutionFailed (objcProperty.Type.AsString, objcProperty.Type.KindSpelling));
+
+				return string.Empty; // fallback
+			}
+		}
+
+		static string GetPropertyTypeName (TypeMapping typeMapping, ClassDeclarationSyntax classDeclaration)
+		{
+			// This method converts a TypeMapping into a usable CLR type name,
+			// taking namespaces into account to avoid ambiguity.
+
+			// If the type has no namespace or is in the global namespace,
+			// we can safely return just the CLR type name.
+			if (typeMapping.TypeSymbol?.ContainingNamespace is null || typeMapping.TypeSymbol.ContainingNamespace.IsGlobalNamespace)
+				return typeMapping.ClrType;
+
+			// Get the namespace of the resolved type (e.g. "MyProject.Models")
+			var typeNamespace = typeMapping.TypeSymbol.ContainingNamespace.ToDisplayString ();
+			var classNamespace = classDeclaration.Ancestors ().OfType<BaseNamespaceDeclarationSyntax> ().FirstOrDefault ()?.Name.ToString ();
+
+			// If the class is in the same namespace as the type, we can return just the CLR type name.
+			return classNamespace == typeNamespace
+				? typeMapping.ClrType
+				: $"{typeNamespace}.{typeMapping.ClrType}";
 		}
 
 		void Write (ObjCMethodDecl objcMethod)

--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -8,6 +8,8 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Serilog;
+using System.Text.RegularExpressions;
+using System.IO.Abstractions;
 using xcsync.Projects;
 using static ClangSharp.Interop.CX_DeclKind;
 using static ClangSharp.Interop.CXTypeKind;
@@ -15,11 +17,12 @@ using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace xcsync.Ast;
 
-class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace workspace) : AstWalker {
+class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace workspace, bool explicitTypes = false) : AstWalker {
+	static readonly IFileSystem FileSystem = new FileSystem ();
 
 	internal async Task<SyntaxTree?> WriteAsync (ObjCInterfaceDecl objcType, SyntaxTree? syntaxTree)
 	{
-		var visitor = new Visitor (Logger, typeService, syntaxTree);
+		var visitor = new Visitor (Logger, typeService, syntaxTree, explicitTypes);
 		await WalkAsync (objcType, visitor).ConfigureAwait (false);
 
 		// Now that we have the basic tree, lets make sure it generates pretty C# code
@@ -72,7 +75,7 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 		return newRoot.SyntaxTree;
 	}
 
-	class Visitor (ILogger logger, ITypeService typeService, SyntaxTree? syntaxTree) : AstVisitor {
+	class Visitor (ILogger logger, ITypeService typeService, SyntaxTree? syntaxTree, bool explicitTypes = false) : AstVisitor {
 
 		public SyntaxTree? SyntaxTree { get; private set; } = syntaxTree;
 
@@ -244,12 +247,13 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			var firstClass = root.DescendantNodes ().OfType<ClassDeclarationSyntax> ().First ();
 
 			var methodName = objcMethod.Name.Replace (":", string.Empty); // TODO: Need to properly convert this to a valid C# method name
+			var senderType = explicitTypes ? GetActionParameterTypeName (objcMethod, firstClass) : "Foundation.NSObject";
 
 			var newMethod = MethodDeclaration (ParseTypeName ("void"), methodName)
 				.AddModifiers (Token (SyntaxKind.PartialKeyword))
 				.AddParameterListParameters (
 					Parameter (Identifier ("sender"))
-						.WithType (ParseTypeName ("Foundation.NSObject")))
+						.WithType (ParseTypeName (senderType)))
 				.AddAttributeLists (
 					AttributeList (SingletonSeparatedList (
 						Attribute (IdentifierName ("Action"),
@@ -262,6 +266,51 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			var newRoot = root.ReplaceNode (firstClass, newClass);
 
 			SyntaxTree = newRoot.SyntaxTree;
+		}
+
+		string GetActionParameterTypeName (ObjCMethodDecl objcMethod, ClassDeclarationSyntax classDeclaration)
+		{
+			var actionParameter = objcMethod.Parameters.FirstOrDefault ();
+
+			if (actionParameter is null)
+				return "Foundation.NSObject";
+
+			string? actionParameterType;
+			try {
+				actionParameterType = actionParameter.OriginalType.AsString;
+			} catch (ArgumentOutOfRangeException) {
+				actionParameterType = TryGetActionParameterTypeFromSource (objcMethod);
+			}
+
+			if (string.IsNullOrEmpty (actionParameterType) || actionParameterType == "id")
+				return "Foundation.NSObject";
+
+			var objcTypeName = actionParameterType.Split (' ') [0];
+			var typeMapping = typeService.QueryTypes (null, objcTypeName).FirstOrDefault ();
+
+			return typeMapping is null
+				? "Foundation.NSObject"
+				: GetPropertyTypeName (typeMapping, classDeclaration);
+		}
+
+		static string? TryGetActionParameterTypeFromSource (ObjCMethodDecl objcMethod)
+		{
+			objcMethod.Extent.Start.GetFileLocation (out var file, out uint line, out _, out _);
+			var fileName = file.Name.CString;
+			if (string.IsNullOrEmpty (fileName) || !FileSystem.File.Exists (fileName))
+				return null;
+
+			objcMethod.Extent.End.GetFileLocation (out _, out uint endLine, out _, out _);
+			var lines = FileSystem.File.ReadAllLines (fileName);
+			var startLine = (int) line;
+			var lastLine = Math.Min ((int) endLine, lines.Length);
+			if (startLine < 1 || startLine > lastLine)
+				return null;
+
+			var source = string.Join ("\n", lines [(startLine - 1)..lastLine]);
+			var match = Regex.Match (source, @":\(([^)]+)\)\s*\w+");
+
+			return match.Success ? match.Groups [1].Value.Trim () : null;
 		}
 
 		protected override Task VisitAttrAsync (Attr attr)

--- a/src/xcsync/Ast/ObjCSyntaxRewriter.cs
+++ b/src/xcsync/Ast/ObjCSyntaxRewriter.cs
@@ -21,6 +21,8 @@ namespace xcsync.Ast;
 class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace workspace, bool explicitTypes = false) : AstWalker {
 	static readonly IFileSystem FileSystem = new FileSystem ();
 
+	static readonly string NSObjectType = "Foundation.NSObject";
+
 	internal async Task<SyntaxTree?> WriteAsync (ObjCInterfaceDecl objcType, SyntaxTree? syntaxTree)
 	{
 		var visitor = new Visitor (Logger, typeService, syntaxTree, explicitTypes);
@@ -136,18 +138,18 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 		void Write (ObjCPropertyDecl objcProperty)
 		{
 			string propertyName = objcProperty.Name;
-			string propertyTypeObjC = string.Empty;			
+			string? propertyTypeObjC;
 			if (objcProperty.Attrs.ToList ().FirstOrDefault (a => a.Kind == CX_AttrKind.CX_AttrKind_IBOutlet) is not null) {
-				propertyTypeObjC = GetObjCTypeName (objcProperty.Type.AsString)!;
+				propertyTypeObjC = GetObjCTypeName (objcProperty.Type.AsString);
 			}
 			// Determine the Objective-C type for the property.
 			// If the property has the IBOutlet attribute, we can get its type directly.
 			// Note: Some properties may not have the IBOutlet attribute (e.g., due to a missing import in the .h file).
 			// In such cases, attempt to parse the type manually from the header file. This can occur when wiring
 			// UI components in Xcode, XCode then doesn't add the import command.
-			else if (!TryGetOutletPropertyTypeFromSource(objcProperty, out propertyTypeObjC)) {
-				return;
-			}
+			else {
+				propertyTypeObjC = TryGetOutletPropertyTypeFromSource (objcProperty);
+			}			
 
 			if(objcProperty.Type.Kind != CXType_ObjCObjectPointer && objcProperty.Type.Kind != CXType_Pointer) {
 				throw new NotImplementedException (Strings.ObjCSyntax.PropertyNotImplementedException (objcProperty.Type.KindSpelling));
@@ -193,11 +195,15 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			SyntaxTree = newRoot.SyntaxTree;
 		}
 
-		string MapObjectCType (string type, ClassDeclarationSyntax classDeclaration)
+		string MapObjectCType (string? type, ClassDeclarationSyntax classDeclaration)
 		{
+			if (string.IsNullOrEmpty (type)) {
+				return NSObjectType;
+			}
+
 			var typeMapping = typeService.QueryTypes (null, type).FirstOrDefault ();
 			if(typeMapping is null) {
-				return "Foundation.NSObject";
+				return NSObjectType;
 			}
 
 			// This method converts a TypeMapping into a usable CLR type name,
@@ -228,7 +234,7 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			var firstClass = root.DescendantNodes ().OfType<ClassDeclarationSyntax> ().First ();
 
 			var methodName = objcMethod.Name.Replace (":", string.Empty); // TODO: Need to properly convert this to a valid C# method name
-			var senderType = explicitTypes ? GetActionParameterTypeName (objcMethod, firstClass) : "Foundation.NSObject";
+			var senderType = explicitTypes ? GetActionParameterTypeName (objcMethod, firstClass) : NSObjectType;
 
 			var newMethod = MethodDeclaration (ParseTypeName ("void"), methodName)
 				.AddModifiers (Token (SyntaxKind.PartialKeyword))
@@ -254,7 +260,7 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			var actionParameter = objcMethod.Parameters.FirstOrDefault ();
 
 			if (actionParameter is null)
-				return "Foundation.NSObject";
+				return NSObjectType;
 
 			string? actionParameterType;
 			try {
@@ -264,7 +270,7 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			}
 
 			if (string.IsNullOrEmpty (actionParameterType) || actionParameterType == "id")
-				return "Foundation.NSObject";
+				return NSObjectType;
 
 			var objcTypeName = actionParameterType.Split (' ') [0];
 			return MapObjectCType (objcTypeName, classDeclaration);
@@ -289,15 +295,15 @@ class ObjCSyntaxRewriter (ILogger Logger, ITypeService typeService, Workspace wo
 			return fileContent.Substring ((int) start, (int) (end - start)).Trim ();
 		}
 
-		static bool TryGetOutletPropertyTypeFromSource (ObjCPropertyDecl objcProperty, out string type)
-		{
-			type = string.Empty;
+		static string? TryGetOutletPropertyTypeFromSource (ObjCPropertyDecl objcProperty)
+		{			
 			var source = GetSourceContent (objcProperty.Extent);
-			if (!string.IsNullOrEmpty (source)) {
-				var match = Regex.Match (source, $@"IBOutlet\s*(?<type>\w*)\s*\*\s*{Regex.Escape (objcProperty.Name)}", RegexOptions.IgnoreCase);
-				type = match.Success ? match.Groups ["type"].Value.Trim () : string.Empty;
-			}
-			return !string.IsNullOrEmpty(type);
+			if (string.IsNullOrEmpty (source)) 
+				return null;
+
+			var match = Regex.Match (source, $@"IBOutlet\s*(?<type>\w*)\s*\*\s*{Regex.Escape (objcProperty.Name)}", RegexOptions.IgnoreCase);
+
+			return match.Success ? match.Groups ["type"].Value.Trim () : null;
 		}
 
 		static string? TryGetActionParameterTypeFromSource (ObjCMethodDecl objcMethod)

--- a/src/xcsync/Commands/SyncCommand.cs
+++ b/src/xcsync/Commands/SyncCommand.cs
@@ -9,16 +9,27 @@ using xcsync.Projects;
 namespace xcsync.Commands;
 
 class SyncCommand : BaseCommand<SyncCommand> {
+	protected Option<bool> explicitTypes = new (
+		["--explicit-types", "-e"],
+		description: Strings.Options.ExplicitTypesDescription,
+		getDefaultValue: () => false);
+
 	public SyncCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "sync", Strings.Commands.SyncDescription)
 	{
-		this.SetHandler (Execute);
+		this.SetHandler (Execute, explicitTypes);
 	}
 
-	public async Task Execute ()
+	protected override void AddOptions ()
+	{
+		base.AddOptions ();
+		Add (explicitTypes);
+	}
+
+	public async Task Execute (bool explicitTypes)
 	{
 		Logger?.Information (Strings.Sync.HeaderInformation, TargetPath, ProjectPath);
 
-		var sync = new SyncContext (fileSystem, new TypeService (Logger!), SyncDirection.FromXcode, ProjectPath, TargetPath, Tfm, Logger!);
+		var sync = new SyncContext (fileSystem, new TypeService (Logger!), SyncDirection.FromXcode, ProjectPath, TargetPath, Tfm, Logger!, explicitTypes: explicitTypes);
 		await sync.SyncAsync ().ConfigureAwait (false);
 	}
 }

--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -26,7 +26,7 @@ class WatchCommand : XcodeCommand<WatchCommand> {
 		this.SetHandler (Execute, project, target, tfm, force, open, incremental, explicitTypes);
 	}
 
-	public async Task Execute (string project, string target, string tfm, bool force, bool open)
+	protected override void AddOptions ()
 	{
 		base.AddOptions ();
 		Add (incremental);

--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -12,12 +12,28 @@ namespace xcsync.Commands;
 
 class WatchCommand : XcodeCommand<WatchCommand> {
 
+	protected Option<bool> incremental = new (
+		["--incremental", "-i"],
+		description: Strings.Options.IncrementalDescription,
+		getDefaultValue: () => false);
+	protected Option<bool> explicitTypes = new (
+		["--explicit-types", "-e"],
+		description: Strings.Options.ExplicitTypesDescription,
+		getDefaultValue: () => false);
+
 	public WatchCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "watch", Strings.Commands.WatchDescription)
 	{
-		this.SetHandler (Execute, project, target, tfm, force, open);
+		this.SetHandler (Execute, project, target, tfm, force, open, incremental, explicitTypes);
 	}
 
 	public async Task Execute (string project, string target, string tfm, bool force, bool open)
+	{
+		base.AddOptions ();
+		Add (incremental);
+		Add (explicitTypes);
+	}
+
+	public async Task Execute (string project, string target, string tfm, bool force, bool open, bool incremental, bool explicitTypes)
 	{
 		using var cts = new CancellationTokenSource ();
 
@@ -31,7 +47,7 @@ class WatchCommand : XcodeCommand<WatchCommand> {
 
 		LogInformation (Strings.Watch.HeaderInformation (ProjectPath, TargetPath, Tfm));
 
-		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, open, force);
+		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, open, force, incremental, explicitTypes);
 
 		// Start an asynchronous task
 		var xcsyncTask = Task.Run (async () => {

--- a/src/xcsync/ContinuousSyncContext.cs
+++ b/src/xcsync/ContinuousSyncContext.cs
@@ -8,7 +8,7 @@ using xcsync.Projects;
 
 namespace xcsync;
 
-class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false)
+class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false, bool incremental = false, bool explicitTypes = false)
 	: SyncContextBase (fileSystem, typeService, projectPath, targetDir, framework, logger) {
 
 	public const string ChangeChannel = "Changes";
@@ -20,7 +20,7 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 		await ConfigureMarilleHub ();
 
 		// Generate initial Xcode project
-		await new SyncContext (FileSystem, new TypeService (Logger), SyncDirection.ToXcode, ProjectPath, TargetDir, Framework.ToString (), Logger, open, force)
+		await new SyncContext (FileSystem, new TypeService (Logger), SyncDirection.ToXcode, ProjectPath, TargetDir, Framework.ToString (), Logger, open, force, explicitTypes: explicitTypes)
 			.SyncAsync (token).ConfigureAwait (false);
 
 		using var xcodeChanges = new ProjectFileChangeMonitor (FileSystem, FileSystem.FileSystemWatcher.New (), Logger);
@@ -33,14 +33,14 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.ToXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.ToXcode, clrChanges, xcodeChanges, incremental, explicitTypes));
 		};
 
 		xcodeChanges.OnFileChanged = async path => {
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.FromXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), path, SyncDirection.FromXcode, clrChanges, xcodeChanges, incremental, explicitTypes));
 		};
 
 		async void ClrFileRenamed (string oldPath, string newPath)
@@ -48,7 +48,7 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.ToXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.ToXcode, clrChanges, xcodeChanges, incremental, explicitTypes));
 		}
 
 		clrChanges.OnFileRenamed = ClrFileRenamed;
@@ -58,7 +58,7 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 			if (token.IsCancellationRequested)
 				return;
 
-			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.FromXcode, clrChanges, xcodeChanges));
+			await Hub.PublishAsync (ChangeChannel, new ChangeMessage (Guid.NewGuid ().ToString (), newPath, SyncDirection.FromXcode, clrChanges, xcodeChanges, incremental, explicitTypes));
 		}
 
 		xcodeChanges.OnFileRenamed = XcodeFileRenamed;
@@ -95,4 +95,3 @@ class ContinuousSyncContext (IFileSystem fileSystem, ITypeService typeService, s
 		// worker now knows to pick up any and all change-related events from the channel in hub
 	}
 }
-

--- a/src/xcsync/Projects/GenObjcH.tt
+++ b/src/xcsync/Projects/GenObjcH.tt
@@ -19,6 +19,9 @@
 #import <<#= @ref #>/<#= @ref #>.h>
 <# } #>
 <# } #>
+<# foreach (var headerReference in typeMapping.HeaderReferences) { #>
+#import "<#= headerReference #>.h"
+<# } #>
 
 
 @interface <#= typeMapping.ObjCType #> : <#= typeMapping.BaseType?.ObjCType is null || typeMapping.BaseType.IsProtocol ? "NSObject" : typeMapping.BaseType?.ObjCType #> {

--- a/src/xcsync/Projects/GenObjcH.tt
+++ b/src/xcsync/Projects/GenObjcH.tt
@@ -40,7 +40,8 @@
 <# } #>
 <# if (typeMapping.Actions is not null) { #>
 <# foreach (var act in typeMapping.Actions) { #>
-- (IBAction)<#= act.ObjCName #>:(id)sender;
+<# var firstParameter = act.Parameters.FirstOrDefault (); #>
+- (IBAction)<#= act.ObjCName #>:(<#= firstParameter?.ObjCType is null || firstParameter.ObjCType == "NSObject" ? "id" : firstParameter.ObjCType.Contains ("*") || firstParameter.ObjCType == "id" || firstParameter.ObjCType.StartsWith ("id<", StringComparison.Ordinal) ? firstParameter.ObjCType : $"{firstParameter.ObjCType} *" #>)<#= firstParameter?.ClrName ?? "sender" #>;
 
 <# } #>
 <# } #>

--- a/src/xcsync/Projects/GenObjcM.tt
+++ b/src/xcsync/Projects/GenObjcM.tt
@@ -26,7 +26,8 @@
 <# } #>
 <# if (typeMapping.Actions is not null) { #>
 <# foreach (var act in typeMapping.Actions) { #>
-- (IBAction)<#= act.ObjCName #>:(id)sender {
+<# var firstParameter = act.Parameters.FirstOrDefault (); #>
+- (IBAction)<#= act.ObjCName #>:(<#= firstParameter?.ObjCType is null || firstParameter.ObjCType == "NSObject" ? "id" : firstParameter.ObjCType.Contains ("*") || firstParameter.ObjCType == "id" || firstParameter.ObjCType.StartsWith ("id<", StringComparison.Ordinal) ? firstParameter.ObjCType : $"{firstParameter.ObjCType} *" #>)<#= firstParameter?.ClrName ?? "sender" #> {
 }
 
 <# } #>

--- a/src/xcsync/Projects/TypeMapping.cs
+++ b/src/xcsync/Projects/TypeMapping.cs
@@ -7,7 +7,9 @@ namespace xcsync.Projects;
 
 
 record TypeMapping (INamedTypeSymbol? TypeSymbol, string ClrType, string ObjCType, TypeMapping? BaseType, bool IsModel, bool IsProtocol,
-	bool InDesigner, List<IBOutlet>? Outlets, List<IBAction>? Actions, HashSet<string> References, bool IsInSource = false, bool HasChanges = false);
+	bool InDesigner, List<IBOutlet>? Outlets, List<IBAction>? Actions, HashSet<string> References, bool IsInSource = false, bool HasChanges = false) {
+	public List<string> HeaderReferences { get; init; } = [];
+}
 
 
 class IBOutlet (string clrName, string objcName, string clrType, string? objcType, bool isCollection) {

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -253,7 +253,11 @@ class TypeService (ILogger Logger) : ITypeService {
 
 				var index = 0;
 				foreach (var param in method.Parameters) {
-					parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type)));
+					var actionObjCType = GetObjCType (targetPlatform, (INamedTypeSymbol) param.Type);
+					parameters.Add (new IBActionParameter (param.Name, strings? [index].Length == 0 ? null : strings? [index], param.Type.MetadataName, actionObjCType));
+					if (actionObjCType is not null && SymbolEqualityComparer.Default.Equals (param.Type.ContainingAssembly, type.ContainingAssembly))
+						AddHeaderReference (headerReferences, actionObjCType, objCName);
+
 					index++;
 					refs.Add (param.ContainingNamespace.Name);
 				}

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -183,6 +183,7 @@ class TypeService (ILogger Logger) : ITypeService {
 		var clrName = type.MetadataName;
 		var objCName = type.Name;
 		HashSet<string> refs = [];
+		List<string> headerReferences = [];
 
 		if (clrTypes.TryGetValue (clrName, out var existingTypeMapping))
 			return existingTypeMapping;
@@ -194,6 +195,8 @@ class TypeService (ILogger Logger) : ITypeService {
 		}
 
 		var baseTypeMapping = ConvertToTypeMapping (targetPlatform, baseType);
+		if (baseType.Locations.Any (l => l.IsInSource) && baseTypeMapping is not null && !baseTypeMapping.IsProtocol)
+			AddHeaderReference (headerReferences, baseTypeMapping.ObjCType, objCName);
 
 		foreach (var a in type.GetAttributes ()) {
 			switch (a.AttributeClass?.Name) {
@@ -223,12 +226,15 @@ class TypeService (ILogger Logger) : ITypeService {
 				if (outletAttribute is null)
 					continue;
 
+				var outletObjCType = GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type);
 				outlets.Add (new IBOutlet (
 					clrName: property.Name,
 					objcName: GetName (outletAttribute) ?? property.Name,
 					clrType: property.Type.MetadataName,
-					objcType: GetObjCType (targetPlatform, (INamedTypeSymbol) property.Type),
+					objcType: outletObjCType,
 					isCollection: property.Type.TypeKind == TypeKind.Array));
+				if (property.Type.Locations.Any (l => l.IsInSource) && outletObjCType is not null)
+					AddHeaderReference (headerReferences, outletObjCType, objCName);
 
 				refs.Add (property.ContainingNamespace.Name);
 			}
@@ -263,9 +269,19 @@ class TypeService (ILogger Logger) : ITypeService {
 
 		var typeMapping = new TypeMapping (type, clrName, objCName, baseTypeMapping, isModel, isProtocol, InDesignerFile (type, objCName),
 			outlets.Count == 0 ? null : outlets, actions.Count == 0 ? null : actions,
-			refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ());
+			refs.Intersect (xcSync.ApplePlatforms [targetPlatform].SupportedFrameworks.Keys).ToHashSet ()) {
+			HeaderReferences = headerReferences
+		};
 
 		return typeMapping;
+	}
+
+	static void AddHeaderReference (List<string> headerReferences, string reference, string objCName)
+	{
+		if (reference == objCName || headerReferences.Contains (reference))
+			return;
+
+		headerReferences.Add (reference);
 	}
 
 	bool InDesignerFile (ITypeSymbol type, string objCName)

--- a/src/xcsync/Projects/XcodeWorkspace.cs
+++ b/src/xcsync/Projects/XcodeWorkspace.cs
@@ -22,7 +22,7 @@ using static ClangSharp.Interop.CXTranslationUnit_Flags;
 
 namespace xcsync.Projects;
 
-partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework) :
+partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeService typeService, string name, string projectPath, string framework, bool explicitTypes = false) :
 	SyncableProject (fileSystem, logger, typeService, name, projectPath, framework, new ExtensionFilter (".pbxproj", ".m", ".h", ".storyboard")) {
 
 	static CXIndex cxIndex = CXIndex.Create ();
@@ -182,7 +182,7 @@ partial class XcodeWorkspace (IFileSystem fileSystem, ILogger logger, ITypeServi
 			}
 			if (syntaxTree is null) return;
 
-			var rewriter = new ObjCSyntaxRewriter (Logger, TypeService, new AdhocWorkspace ());
+			var rewriter = new ObjCSyntaxRewriter (Logger, TypeService, new AdhocWorkspace (), explicitTypes);
 
 			var newClass = await rewriter.WriteAsync (objcType.ClassInterface, syntaxTree);
 			var root = syntaxTree!.GetRoot ();

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -146,7 +146,9 @@ static class Strings {
 		internal static string Visiting(string visitor, string decl) => string.Format(Resources.Strings.ObjCSyntax_Visiting, visitor, decl);
 		internal static string PropertyNotImplementedException(string decl) => string.Format(Resources.Strings.ObjCSyntax_PropertyNotImplementedException, decl);
 		internal static string ParsingProperty(string visitor, string decl) => string.Format(Resources.Strings.ObjCSyntax_ParsingProperty, visitor, decl);
- 	}
+		internal static string TypeMappingNotFound(string propertyType, string kind) => string.Format(Resources.Strings.ObjCSyntax_TypeMappingNotFound, propertyType, kind);
+		internal static string PropertyTypeResolutionFailed(string propertyType, string kind) => string.Format(Resources.Strings.ObjCSyntax_PropertyTypeResolutionFailed, propertyType, kind);
+  	}
 
 	internal static class Workers 
 	{

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -18,6 +18,8 @@ static class Strings {
 		internal static string TfmDescription => Resources.Strings.Options_Tfm_Description;
 		internal static string VerbosityDescription => Resources.Strings.Options_Verbosity_Description;
 		internal static string DotnetPathDescription => Resources.Strings.Options_DotnetPath_Description;
+		internal static string IncrementalDescription => Resources.Strings.Options_Incremental_Description;
+		internal static string ExplicitTypesDescription => Resources.Strings.Options_ExplicitTypes_Description;
 	}
 
 	internal static class Commands {

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -90,6 +90,7 @@ static class Strings {
 		internal static string ResumingMonitoring => Resources.Strings.Watch_ResumingMonitoring;
 		internal static string WorkerException (string messageId, string exceptionMessage) => string.Format (Resources.Strings.Watch_WorkerException, messageId, exceptionMessage);
 		internal static string StopWatchProcess => Resources.Strings.Watch_StopWatchProcess;
+		internal static string IncrementalSyncing (string path) => string.Format (Resources.Strings.Watch_IncrementalSyncing, path);
 	}
 
 	internal static class TypeService {
@@ -143,13 +144,12 @@ static class Strings {
 	}
 
 	internal static class ObjCSyntax
- 	{
+  	{
 		internal static string ObjCImplementationDeclFound(string decl) => string.Format(Resources.Strings.ObjCSyntax_ObjCImplementationDeclFound, decl);
 		internal static string Visiting(string visitor, string decl) => string.Format(Resources.Strings.ObjCSyntax_Visiting, visitor, decl);
 		internal static string PropertyNotImplementedException(string decl) => string.Format(Resources.Strings.ObjCSyntax_PropertyNotImplementedException, decl);
 		internal static string ParsingProperty(string visitor, string decl) => string.Format(Resources.Strings.ObjCSyntax_ParsingProperty, visitor, decl);
-		internal static string TypeMappingNotFound(string propertyType, string kind) => string.Format(Resources.Strings.ObjCSyntax_TypeMappingNotFound, propertyType, kind);
-		internal static string PropertyTypeResolutionFailed(string propertyType, string kind) => string.Format(Resources.Strings.ObjCSyntax_PropertyTypeResolutionFailed, propertyType, kind);
+		internal static string UnresolvedPropertyType(string propertyName, string objcType) => string.Format(Resources.Strings.ObjCSyntax_UnresolvedPropertyType, propertyName, objcType);
   	}
 
 	internal static class Workers 

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -349,6 +349,10 @@
 	<data name="Watch.StopWatchProcess" xml:space="preserve">
 		<value>User has requested to stop the sync process. Changes will no longer be processed.</value>
 	</data>
+	<data name="Watch.IncrementalSyncing" xml:space="preserve">
+		<value>Incrementally syncing changes related to '{0}'</value>
+		<comment>{0} is the path of the changed file</comment>
+	</data>
 
     <!-- Type Service Messages -->
     <data name="TypeService.DuplicateType" xml:space="preserve">
@@ -527,13 +531,9 @@ v    <data name="XcodeWorkspace.UsingDefaultSdkRoot" xml:space="preserve">
 		<value>[{0}] Parsing property type '{0}'</value>
         <comment>{0} is the name of the visitor class, {1} is the declaration kind name</comment>
 	</data>
-    <data name="ObjCSyntax.TypeMappingNotFound" xml:space="preserve">
-		<value>Type mapping not found for property type '{0}' (Kind: {1})</value>
-        <comment>{0} is the property type, {1} is the kind spelling</comment>
-	</data>
-    <data name="ObjCSyntax.PropertyTypeResolutionFailed" xml:space="preserve">
-		<value>Failed to resolve property type for '{0}' (Kind: {1})</value>
-        <comment>{0} is the property type, {1} is the kind spelling</comment>
+    <data name="ObjCSyntax.UnresolvedPropertyType" xml:space="preserve">
+		<value>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</value>
+        <comment>{0} is the outlet property name, {1} is the Objective-C type name</comment>
 	</data>
 
 	<!-- Workers -->

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -152,6 +152,13 @@
 		<value>Set the path to the .NET SDK, when not provided will use the path from the parent process if it is 'dotnet' otherwise falls back to the 'dotnet' on the PATH.</value>
 	</data>
 
+	<data name="Options.Incremental.Description" xml:space="preserve">
+	  <value>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</value>
+	</data>
+	<data name="Options.ExplicitTypes.Description" xml:space="preserve">
+	  <value>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</value>
+	</data>
+
 	<!-- Commands -->
 	<data name="Commands.Generate.Description" xml:space="preserve">
 		<value>generate a Xcode project at the path specified by --target from the project identified by --project</value>

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -520,6 +520,14 @@ v    <data name="XcodeWorkspace.UsingDefaultSdkRoot" xml:space="preserve">
 		<value>[{0}] Parsing property type '{0}'</value>
         <comment>{0} is the name of the visitor class, {1} is the declaration kind name</comment>
 	</data>
+    <data name="ObjCSyntax.TypeMappingNotFound" xml:space="preserve">
+		<value>Type mapping not found for property type '{0}' (Kind: {1})</value>
+        <comment>{0} is the property type, {1} is the kind spelling</comment>
+	</data>
+    <data name="ObjCSyntax.PropertyTypeResolutionFailed" xml:space="preserve">
+		<value>Failed to resolve property type for '{0}' (Kind: {1})</value>
+        <comment>{0} is the property type, {1} is the kind spelling</comment>
+	</data>
 
 	<!-- Workers -->
     <data name="FileWorker.WroteFile" xml:space="preserve">

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Nepodporovaný typ vlastnosti {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Nepodporovaný typ vlastnosti {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Návštěva {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Nastavte cestu k sadě .NET SDK. Pokud se nezadá, použije se cesta z nadřazeného procesu (pokud je to dotnet, jinak se vrátí k dotnet v parametru PATH).</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Vynutit přepsání existujícího projektu Xcode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Průběžná synchronizace souborů mezi {0} a {1} pro platformu {2}</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Nicht unterstützter Eigenschaftstyp „{0}“</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Legen Sie den Pfad zum .NET SDK fest. Wenn keine Angabe erfolgt, wird der Pfad aus dem übergeordneten Prozess verwendet, wenn er "dotnet" ist. Andernfalls wird auf "dotnet" im PFAD zurückgesetzt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Überschreiben eines vorhandenen Xcode-Projekts erzwingen</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Fortlaufendes Synchronisieren von Dateien zwischen „{0}“ und „{1}“ für die Plattform „{2}“</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Nicht unterstützter Eigenschaftstyp „{0}“</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] {{{1}}} wird besucht.</target>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Tipo de propiedad no compatible {0}.</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Establezca la ruta de acceso al SDK de .NET; cuando no se proporcione usará la ruta de acceso del proceso primario si es "dotnet"; de lo contrario vuelve a "dotnet" en PATH.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Forzar la sobreescritura de un proyecto de Xcode existente</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizando archivos continuamente entre "{0}" y "{1}" para la plataforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Tipo de propiedad no compatible {0}.</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Visitando {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Définissez le chemin d’accès au Kit de développement logiciel (SDK) .NET, s’il n’est pas fourni, il utilise le chemin d’accès du processus parent s’il s’agit de 'dotnet'. Sinon, il revient au 'dotnet' dans CHEMIN D’ACCÈS.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Forcer le remplacement d’un projet Xcode existant</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Synchronisation continue des fichiers entre « {0} » et « {1} » pour la plateforme « {2} ».</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Type de propriété {0} non pris en charge</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Visite de {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Type de propriété {0} non pris en charge</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Impostare il percorso di .NET SDK. Se non viene specificato, verrà usato il percorso del processo padre se è 'dotnet'. In caso contrario, verrà usato 'dotnet' in PATH.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Forza sovrascrittura di un progetto Xcode esistente</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizzazione continua dei file tra "{0}" e "{1}" per la piattaforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Tipo di proprietà non supportato {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Tipo di proprietà non supportato {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Visita di {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">サポートされないプロパティの種類 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -242,9 +242,19 @@
         <target state="translated">.NET SDK へのパスを設定します。指定しない場合、親プロセスからのパスが 'dotnet' の場合はそのパスを使用し、それ以外の場合は、PATH の 'dotnet' にフォールバックします。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">既存の Xcode プロジェクトを強制的に上書きする</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' プラットフォームの '{0}' と '{1}' の間でファイルを継続的に同期しています。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -222,6 +222,16 @@
         <target state="translated">サポートされないプロパティの種類 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] {{{1}}} にアクセスしています</target>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -222,6 +222,16 @@
         <target state="translated">지원되지 않는 속성 형식 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] 방문 중 {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">지원되지 않는 속성 형식 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -242,9 +242,19 @@
         <target state="translated">.NET SDK의 경로를 설정하며, 제공되지 않을 경우 경로가 'dotnet'인 경우 부모 프로세스의 경로를 사용하고 그렇지 않은 경우 경로의 'dotnet'으로 되돌아갑니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">기존 Xcode 프로젝트 강제 덮어쓰기</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' 플랫폼에 대해 '{0}'에서 '{1}'(으)로 파일을 지속적으로 동기화합니다.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Nieobsługiwany typ właściwości {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Nieobsługiwany typ właściwości {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Odwiedź {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Ustaw ścieżkę do zestawu SDK platformy .NET, jeśli nie zostanie podana, użyje ścieżki z procesu nadrzędnego, jeśli jest to ścieżka „dotnet”, w przeciwnym razie powróci do ścieżki „dotnet” w ścieżce PATH.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Wymuś zastąpienie istniejącego projektu Xcode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Ciągła synchronizacja plików między platformą „{0}” i „{1}” dla platformy „{2}”.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Defina o caminho para o SDK do .NET, quando não fornecido usará o caminho do processo pai se for "dotnet", caso contrário, retornará ao "dotnet" no PATH.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Forçar a substituição de um projeto Xcode existente</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Sincronizando continuamente arquivos entre "{0}" e "{1}" para a plataforma "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Tipo de propriedade sem suporte {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Tipo de propriedade sem suporte {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Visitando {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Задайте путь к пакету SDK .NET. Если он не указан, будет использоваться путь из родительского процесса, если это «dotnet», в противном случае возвращается к «dotnet» в PATH.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Принудительная перезапись существующего проекта Xcode</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">Непрерывная синхронизация файлов между "{0}" и "{1}" для платформы "{2}".</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -222,6 +222,16 @@
         <target state="translated">Неподдерживаемый тип свойства {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] Посещение {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">Неподдерживаемый тип свойства {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -222,6 +222,16 @@
         <target state="translated">{0} özellik türü desteklenmiyor</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] {{{1}}} ziyaret ediliyor</target>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -242,9 +242,19 @@
         <target state="translated">Yolu .NET SDK'sına ayarlayın, sağlanmadıysa, 'dotnet' ise üst işlemden gelen yolu kullan, aksi halde PATH'de 'dotnet' öğesine geri döner.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">Mevcut bir Xcode projesinin üzerine yazmaya zorla</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">'{2}' platformu için '{0}' ve '{1}' arasındaki dosyalar sürekli eşitleniyor.</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">{0} özellik türü desteklenmiyor</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -242,9 +242,19 @@
         <target state="translated">设置 .NET SDK 的路径(如果未提供)，如果为 “dotnet”，则将使用父级进程中的路径，否则将回退到 PATH 上的 “dotnet”。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">强制覆盖现有 Xcode 项目</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">持续在 "{0}" 和 "{1}" 之间为“{2}”平台同步文件。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -222,6 +222,16 @@
         <target state="translated">属性类型“{0}”不受支持</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}]正在访问 {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">属性类型“{0}”不受支持</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -222,6 +222,16 @@
         <target state="translated">不支援的屬性類型 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
+      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
+        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
+        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
+      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
+        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
+        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
+        <note>{0} is the property type, {1} is the kind spelling</note>
+      </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>
         <target state="translated">[{0}] 正在瀏覽 {{{1}}}</target>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../Strings.resx">
     <body>
@@ -222,15 +222,10 @@
         <target state="translated">不支援的屬性類型 {0}</target>
         <note>{0} is the name of the property type</note>
       </trans-unit>
-      <trans-unit id="ObjCSyntax.PropertyTypeResolutionFailed">
-        <source>Failed to resolve property type for '{0}' (Kind: {1})</source>
-        <target state="new">Failed to resolve property type for '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
-      </trans-unit>
-      <trans-unit id="ObjCSyntax.TypeMappingNotFound">
-        <source>Type mapping not found for property type '{0}' (Kind: {1})</source>
-        <target state="new">Type mapping not found for property type '{0}' (Kind: {1})</target>
-        <note>{0} is the property type, {1} is the kind spelling</note>
+      <trans-unit id="ObjCSyntax.UnresolvedPropertyType">
+        <source>Unable to resolve outlet '{0}' with Objective-C type '{1}'.</source>
+        <target state="new">Unable to resolve outlet '{0}' with Objective-C type '{1}'.</target>
+        <note>{0} is the outlet property name, {1} is the Objective-C type name</note>
       </trans-unit>
       <trans-unit id="ObjCSyntax.Visiting">
         <source>[{0}] Visiting {{{1}}}</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -242,9 +242,19 @@
         <target state="translated">將路徑設定為 .NET SDK，如果沒有提供，則將使用父處理序的路徑，如果它是 'dotnet'，否則將後援至 PATH 上的 'dotnet'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Options.ExplicitTypes.Description">
+        <source>Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</source>
+        <target state="new">Use the explicit Objective-C types from Xcode headers when generating designer files instead of defaulting action senders to Foundation.NSObject</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Options.Force.Description">
         <source>Force overwrite of an existing Xcode project</source>
         <target state="translated">強制覆寫現有的 Xcode 專案</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Options.Incremental.Description">
+        <source>Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</source>
+        <target state="new">Enable incremental synchronization, only syncing the files related to the detected change instead of the entire project</target>
         <note />
       </trans-unit>
       <trans-unit id="Options.Open.Description">
@@ -383,6 +393,11 @@
         <source>Continuously syncing files between '{0}' and '{1}' for '{2}' platform.</source>
         <target state="translated">在 '{2}' 平台持續同步 '{0}' 和 '{1}' 之間的檔案。</target>
         <note>{0} is the path to the project file, {1} is the path to the target project, {2} is the target platform moniker</note>
+      </trans-unit>
+      <trans-unit id="Watch.IncrementalSyncing">
+        <source>Incrementally syncing changes related to '{0}'</source>
+        <target state="new">Incrementally syncing changes related to '{0}'</target>
+        <note>{0} is the path of the changed file</note>
       </trans-unit>
       <trans-unit id="Watch.InputRedirectedInstructions">
         <source>&gt;&gt;&gt; Input is redirected, waiting for SIGINT &lt;&lt;&lt;</source>

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -11,7 +11,18 @@ using xcsync.Workers;
 
 namespace xcsync;
 
-class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirection Direction, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false, bool explicitTypes = false, string? changedFilePath = null)
+class SyncContext (
+	IFileSystem fileSystem,
+	ITypeService typeService,
+	SyncDirection Direction,
+	string projectPath,
+	string targetDir,
+	string framework,
+	ILogger logger,
+	bool open = false,
+	bool force = false,
+	bool explicitTypes = false,
+	string? changedFilePath = null)
 	: SyncContextBase (fileSystem, typeService, projectPath, targetDir, framework, logger) {
 
 	public const string FileChannel = "Files";
@@ -124,7 +135,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		};
 		xcodeObjects.Add (pbxGroup.Token, pbxGroup);
 
-		foreach (var t in TypeService.QueryTypes ().Where (t => t is not null && t.IsInSource)) {
+		foreach (var t in TypeService.QueryTypes ().Where (t => t is not null && t.IsInSource && (changedFilePath is null || t.TypeSymbol?.Locations.Any (l => l.SourceTree?.FilePath == changedFilePath) == true))) {
 
 			if (t is null) continue; // Only needed to keep the compiler happy
 
@@ -148,6 +159,12 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		Logger?.Debug (Strings.Generate.GeneratedFiles);
+
+		if (changedFilePath is not null) {
+			// For incremental sync, only the source files need to be regenerated.
+			// Resources and the Xcode project structure are not affected.
+			return;
+		}
 
 		// leverage msbuild to get the list of files in the project
 		var filePaths = Scripts.GetFileItemsFromProject (ProjectPath, Framework.Platform, targetPlatform);
@@ -494,7 +511,16 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		}
 
 		List<Task> tasks = [];
-		foreach (var syncItem in xcodeWorkspace.Items) {
+		IEnumerable<ISyncableItem> itemsToProcess = xcodeWorkspace.Items;
+		if (changedFilePath is not null) {
+			var changedFileBaseName = FileSystem.Path.GetFileNameWithoutExtension (changedFilePath);
+			itemsToProcess = itemsToProcess.Where (item => item switch {
+				SyncableType type => FileSystem.Path.GetFileNameWithoutExtension (type.FilePath) == changedFileBaseName,
+				SyncableContent content => content.SourcePath == changedFilePath,
+				_ => false
+			});
+		}
+		foreach (var syncItem in itemsToProcess) {
 			var basePath = string.Empty;
 			if (syncItem is SyncableContent content && (
 				content.SourcePath.EndsWith (".xcassets", StringComparison.OrdinalIgnoreCase) ||
@@ -515,10 +541,15 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 				tasks.Add (tcs.Task);
 			}
 		}
-		Task.WaitAll ([.. tasks], token);
+		Task.WaitAll ([..tasks], token);
 
 		var typesToWrite = TypeService.QueryTypes (null, null) // All Types
 			.Where (t => t is not null && t.InDesigner) ?? []; // Filter Types that are in .designer.cs files TODO: This may be wrong, there are types that don't exist in *.designer.cs files
+
+		if (changedFilePath is not null) {
+			var changedFileBaseName = FileSystem.Path.GetFileNameWithoutExtension (changedFilePath);
+			typesToWrite = typesToWrite.Where (t => t?.ObjCType == changedFileBaseName);
+		}
 
 		// TODO: What happens when a new type is added to the Xcode project, like new view controllers?
 

--- a/src/xcsync/SyncContext.cs
+++ b/src/xcsync/SyncContext.cs
@@ -11,7 +11,7 @@ using xcsync.Workers;
 
 namespace xcsync;
 
-class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirection Direction, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false)
+class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirection Direction, string projectPath, string targetDir, string framework, ILogger logger, bool open = false, bool force = false, bool explicitTypes = false, string? changedFilePath = null)
 	: SyncContextBase (fileSystem, typeService, projectPath, targetDir, framework, logger) {
 
 	public const string FileChannel = "Files";
@@ -471,7 +471,7 @@ class SyncContext (IFileSystem fileSystem, ITypeService typeService, SyncDirecti
 		var dotNetProject = new ClrProject (FileSystem, Logger, TypeService, projectName, ProjectPath, Framework.ToString ());
 		await dotNetProject.OpenProject ().ConfigureAwait (false);
 
-		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString ());
+		var xcodeWorkspace = new XcodeWorkspace (FileSystem, Logger, TypeService, projectName, TargetDir, Framework.ToString (), explicitTypes);
 
 		var xcodeproj = FileSystem.Path.Combine (xcodeWorkspace.RootPath, $"{projectName}.xcodeproj");
 		var pbxProjPath = FileSystem.Path.Combine (xcodeproj, "project.pbxproj");

--- a/src/xcsync/Workers/ChangeWorker.cs
+++ b/src/xcsync/Workers/ChangeWorker.cs
@@ -8,7 +8,7 @@ using xcsync.Workers;
 
 namespace xcsync;
 
-record struct ChangeMessage (string Id, string Path, SyncDirection Direction, ProjectFileChangeMonitor ClrMonitor, ProjectFileChangeMonitor XcodeMonitor);
+record struct ChangeMessage (string Id, string Path, SyncDirection Direction, ProjectFileChangeMonitor ClrMonitor, ProjectFileChangeMonitor XcodeMonitor, bool Incremental = false, bool ExplicitTypes = false);
 
 class ChangeWorker (IFileSystem FileSystem, string ProjectPath, string TargetDir, string Framework, ILogger Logger, ClrProject ClrProject, XcodeWorkspace XcodeProject) : BaseWorker<ChangeMessage> {
 	public override async Task ConsumeAsync (ChangeMessage message, CancellationToken cancellationToken = default)
@@ -17,7 +17,10 @@ class ChangeWorker (IFileSystem FileSystem, string ProjectPath, string TargetDir
 		message.ClrMonitor.StopMonitoring ();
 		message.XcodeMonitor.StopMonitoring ();
 		Logger.Debug (Strings.Watch.Syncing);
-		await new SyncContext (FileSystem, new TypeService (Logger), message.Direction, ProjectPath, TargetDir, Framework, Logger, open: false, force: message.Direction == SyncDirection.ToXcode).SyncAsync (cancellationToken);
+		var changedFilePath = message.Incremental ? message.Path : null;
+		if (changedFilePath is not null)
+			Logger.Debug (Strings.Watch.IncrementalSyncing (changedFilePath));
+		await new SyncContext (FileSystem, new TypeService (Logger), message.Direction, ProjectPath, TargetDir, Framework, Logger, open: false, force: changedFilePath is null && message.Direction == SyncDirection.ToXcode, explicitTypes: message.ExplicitTypes, changedFilePath: changedFilePath).SyncAsync (cancellationToken);
 		Logger.Debug (Strings.Watch.ResumingMonitoring);
 		message.ClrMonitor.StartMonitoring (ClrProject, cancellationToken);
 		message.XcodeMonitor.StartMonitoring (XcodeProject, cancellationToken);

--- a/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
+++ b/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
@@ -18,6 +18,7 @@ public class ObjCSyntaxRewriterTest {
 	[Theory]
 	[InlineData (ViewControllerObjC, ViewControllerCSharp)]
 	[InlineData (ViewControllerOutletObjC, ViewControllerOutletCSharp)]
+	[InlineData (ViewControllerCustomOutletObjC, ViewControllerCustomOutletCSharp)]
 	[InlineData (ViewControllerActionObjC, ViewControllerActionCSharp)]
 	public async void WriteAsync_ObjCInterfaceDecl_TranslatesToCorrectValidSyntaxTree (string inputContents, string expectedOutput)
 	{
@@ -29,11 +30,15 @@ public class ObjCSyntaxRewriterTest {
 
 		var logger = new Mock<ILogger> ();
 		var TypeService = new Mock<TypeService> (logger.Object);
-		var NSTextFieldTypeMapping = new TypeMapping (null, "NSTextField", "NSTextField", null, false, false, false, null, null, []);
+		var NSTextFieldTypeMapping = new TypeMapping (CreateTypeSymbol ("NSTextField", "AppKit"), "NSTextField", "NSTextField", null, false, false, false, null, null, []);
+		var PrimaryButtonTypeMapping = new TypeMapping (CreateTypeSymbol ("PrimaryButton", "TestCustomControl"), "PrimaryButton", "PrimaryButton", null, false, false, false, null, null, []);
 
 		TypeService.Setup (
 			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "NSTextField"))
 		).Returns ([NSTextFieldTypeMapping]);
+		TypeService.Setup (
+			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "PrimaryButton"))
+		).Returns ([PrimaryButtonTypeMapping]);
 
 		var index = CXIndex.Create ();
 		using var unsavedFile = CXUnsavedFile.Create (DefaultInputFileName, inputContents);
@@ -105,7 +110,7 @@ partial class ViewController
 partial class ViewController
 {
     [Outlet]
-    NSTextField Name { get; set; }
+    AppKit.NSTextField Name { get; set; }
 
     void ReleaseDesignerOutlets()
     {
@@ -113,6 +118,38 @@ partial class ViewController
         {
             Name.Dispose();
             Name = null;
+        }
+    }
+}";
+	const string ViewControllerCustomOutletObjC = @"
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+@class PrimaryButton;
+
+@interface ViewController : NSViewController {
+}
+
+@property (weak) IBOutlet PrimaryButton *CustomButton;
+
+@end
+
+@implementation ViewController
+ 
+@end
+";
+	const string ViewControllerCustomOutletCSharp = @"[Register(""ViewController"")]
+partial class ViewController
+{
+    [Outlet]
+    TestCustomControl.PrimaryButton CustomButton { get; set; }
+
+    void ReleaseDesignerOutlets()
+    {
+        if (CustomButton != null)
+        {
+            CustomButton.Dispose();
+            CustomButton = null;
         }
     }
 }";
@@ -143,4 +180,18 @@ partial class ViewController
     {
     }
 }";
+
+	static INamedTypeSymbol CreateTypeSymbol (string name, string? namespaceName)
+	{
+		var typeSymbol = new Mock<INamedTypeSymbol> ();
+		typeSymbol.Setup (x => x.Name).Returns (name);
+		typeSymbol.Setup (x => x.MetadataName).Returns (name);
+
+		var namespaceSymbol = new Mock<INamespaceSymbol> ();
+		namespaceSymbol.Setup (x => x.IsGlobalNamespace).Returns (string.IsNullOrEmpty (namespaceName));
+		namespaceSymbol.Setup (x => x.ToDisplayString (null)).Returns (namespaceName ?? string.Empty);
+		typeSymbol.Setup (x => x.ContainingNamespace).Returns (namespaceSymbol.Object);
+
+		return typeSymbol.Object;
+	}
 }

--- a/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
+++ b/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
@@ -123,6 +123,91 @@ public class ObjCSyntaxRewriterTest {
 		Directory.Delete (directory, true);
 	}
 
+	[Fact]
+	public async void WriteAsync_ObjCInterfaceDecl_WithMissingImport_UsesSourceTypeFallback ()
+	{
+		var logger = new Mock<ILogger> ();
+		var TypeService = new Mock<TypeService> (logger.Object);
+
+		TypeService.Setup (
+			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "WKWebView"))
+		).Returns ([CreateTypeMapping ("WKWebView", "WebKit")]);
+
+		var directory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+		Directory.CreateDirectory (directory);
+		var inputFileName = Path.Combine (directory, "ClangUnsavedFile.h");
+		await File.WriteAllTextAsync (inputFileName, ViewControllerMissingImportOutletObjC);
+		var index = CXIndex.Create ();
+
+		CXTranslationUnit_Flags DefaultTranslationUnitFlags = CXTranslationUnit_None
+			| CXTranslationUnit_IncludeAttributedTypes
+			| CXTranslationUnit_VisitImplicitAttributes;
+
+		string [] clangCommandLineArgs = [
+				"-x",
+			"objective-c",
+			"-target",
+			"arm64-apple-macosx",
+			"-isysroot",
+			Path.Combine (Scripts.SelectXcode (), "Contents", "Developer", "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX.sdk"),
+		];
+
+		var translationUnitError = CXTranslationUnit.TryParse (index, inputFileName, clangCommandLineArgs, [], DefaultTranslationUnitFlags, out var handle);
+		using var node = TranslationUnit.GetOrCreate (handle);
+
+		var cursor = node.TranslationUnitDecl.CursorChildren [^2];
+		var decl = (ObjCInterfaceDecl) cursor;
+
+		var walker = new ObjCSyntaxRewriter (logger.Object, TypeService.Object, new AdhocWorkspace ());
+		var newSyntax = await walker.WriteAsync (decl, null);
+		var actualOutput = newSyntax!.GetRoot ().ToFullString ();
+
+		Assert.NotNull (newSyntax);
+		Assert.Equal (ViewControllerMissingImportOutletCSharp, actualOutput);
+		Directory.Delete (directory, true);
+	}
+
+	[Fact]
+	public async void WriteAsync_ObjCInterfaceDecl_WithUnresolvedOutlet_LogsErrorAndSkipsProperty ()
+	{
+		var logger = new Mock<ILogger> ();
+		var TypeService = new Mock<TypeService> (logger.Object);
+
+		var directory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+		Directory.CreateDirectory (directory);
+		var inputFileName = Path.Combine (directory, "ClangUnsavedFile.h");
+		await File.WriteAllTextAsync (inputFileName, ViewControllerUnresolvedOutletObjC);
+		var index = CXIndex.Create ();
+
+		CXTranslationUnit_Flags DefaultTranslationUnitFlags = CXTranslationUnit_None
+			| CXTranslationUnit_IncludeAttributedTypes
+			| CXTranslationUnit_VisitImplicitAttributes;
+
+		string [] clangCommandLineArgs = [
+				"-x",
+			"objective-c",
+			"-target",
+			"arm64-apple-macosx",
+			"-isysroot",
+			Path.Combine (Scripts.SelectXcode (), "Contents", "Developer", "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX.sdk"),
+		];
+
+		var translationUnitError = CXTranslationUnit.TryParse (index, inputFileName, clangCommandLineArgs, [], DefaultTranslationUnitFlags, out var handle);
+		using var node = TranslationUnit.GetOrCreate (handle);
+
+		var cursor = node.TranslationUnitDecl.CursorChildren [^2];
+		var decl = (ObjCInterfaceDecl) cursor;
+
+		var walker = new ObjCSyntaxRewriter (logger.Object, TypeService.Object, new AdhocWorkspace ());
+		var newSyntax = await walker.WriteAsync (decl, null);
+		var actualOutput = newSyntax!.GetRoot ().ToFullString ();
+
+		Assert.NotNull (newSyntax);
+		Assert.Equal (ViewControllerCSharp, actualOutput);
+		logger.Verify (x => x.Error (It.Is<string> (s => s.Contains ("MysteryView") && s.Contains ("WebView"))), Times.Once);
+		Directory.Delete (directory, true);
+	}
+
 	const string ViewControllerObjC = @"
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>
@@ -272,6 +357,51 @@ partial class ViewController
     {
     }
 }";
+	const string ViewControllerMissingImportOutletObjC = @"
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+@interface ViewController : NSViewController {
+}
+
+@property (strong) IBOutlet WKWebView *WebView;
+
+@end
+
+@implementation ViewController
+ 
+@end
+";
+	const string ViewControllerMissingImportOutletCSharp = @"[Register(""ViewController"")]
+partial class ViewController
+{
+    [Outlet]
+    WebKit.WKWebView WebView { get; set; }
+
+    void ReleaseDesignerOutlets()
+    {
+        if (WebView != null)
+        {
+            WebView.Dispose();
+            WebView = null;
+        }
+    }
+}";
+	const string ViewControllerUnresolvedOutletObjC = @"
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+@interface ViewController : NSViewController {
+}
+
+@property (strong) IBOutlet MysteryView *WebView;
+
+@end
+
+@implementation ViewController
+ 
+@end
+";
 	const string PrimaryButtonObjC = @"
 #import <AppKit/AppKit.h>
 #import <Foundation/Foundation.h>

--- a/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
+++ b/test/xcsync.tests/Ast/ObjCSyntaxRewriterTest.cs
@@ -39,6 +39,9 @@ public class ObjCSyntaxRewriterTest {
 		TypeService.Setup (
 			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "PrimaryButton"))
 		).Returns ([PrimaryButtonTypeMapping]);
+		TypeService.Setup (
+			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "NSButton"))
+		).Returns ([CreateTypeMapping ("NSButton", "AppKit")]);
 
 		var index = CXIndex.Create ();
 		using var unsavedFile = CXUnsavedFile.Create (DefaultInputFileName, inputContents);
@@ -70,6 +73,54 @@ public class ObjCSyntaxRewriterTest {
 		// Assert
 		Assert.NotNull (newSyntax);
 		Assert.Equal (expectedOutput, actualOutput);
+	}
+
+	[Theory]
+	[InlineData (false, ViewControllerExplicitActionCSharpImplicit)]
+	[InlineData (true, ViewControllerExplicitActionCSharpExplicit)]
+	public async void WriteAsync_ObjCInterfaceDecl_WithExplicitTypes_UsesActionParameterTypeWhenEnabled (bool explicitTypes, string expectedOutput)
+	{
+		var logger = new Mock<ILogger> ();
+		var TypeService = new Mock<TypeService> (logger.Object);
+
+		TypeService.Setup (
+			x => x.QueryTypes (It.IsAny<string> (), It.Is<string> (s => s == "PrimaryButton"))
+		).Returns ([CreateTypeMapping ("PrimaryButton", "TestCustomControl")]);
+
+		var directory = Path.Combine (Path.GetTempPath (), Path.GetRandomFileName ());
+		Directory.CreateDirectory (directory);
+		var inputFileName = Path.Combine (directory, "ClangUnsavedFile.h");
+		var primaryButtonFileName = Path.Combine (directory, "PrimaryButton.h");
+		await File.WriteAllTextAsync (inputFileName, ViewControllerExplicitActionObjC);
+		await File.WriteAllTextAsync (primaryButtonFileName, PrimaryButtonObjC);
+		var index = CXIndex.Create ();
+
+		CXTranslationUnit_Flags DefaultTranslationUnitFlags = CXTranslationUnit_None
+			| CXTranslationUnit_IncludeAttributedTypes
+			| CXTranslationUnit_VisitImplicitAttributes;
+
+		string [] clangCommandLineArgs = [
+				"-x",
+			"objective-c",
+			"-target",
+			"arm64-apple-macosx",
+			"-isysroot",
+			Path.Combine (Scripts.SelectXcode (), "Contents", "Developer", "Platforms", "MacOSX.platform", "Developer", "SDKs", "MacOSX.sdk"),
+		];
+
+		var translationUnitError = CXTranslationUnit.TryParse (index, inputFileName, clangCommandLineArgs, [], DefaultTranslationUnitFlags, out var handle);
+		using var node = TranslationUnit.GetOrCreate (handle);
+
+		var cursor = node.TranslationUnitDecl.CursorChildren [^2];
+		var decl = (ObjCInterfaceDecl) cursor;
+
+		var walker = new ObjCSyntaxRewriter (logger.Object, TypeService.Object, new AdhocWorkspace (), explicitTypes);
+		var newSyntax = await walker.WriteAsync (decl, null);
+		var actualOutput = newSyntax!.GetRoot ().ToFullString ();
+
+		Assert.NotNull (newSyntax);
+		Assert.Equal (expectedOutput, actualOutput);
+		Directory.Delete (directory, true);
 	}
 
 	const string ViewControllerObjC = @"
@@ -180,6 +231,54 @@ partial class ViewController
     {
     }
 }";
+	const string ViewControllerExplicitActionObjC = @"
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+#import ""PrimaryButton.h""
+
+@interface ViewController : NSViewController {
+}
+
+- (IBAction)Button:(id)sender;
+- (IBAction)OnButtonClick2:(PrimaryButton *)sender;
+
+@end
+
+@implementation ViewController
+ 
+@end
+";
+const string ViewControllerExplicitActionCSharpImplicit = @"[Register(""ViewController"")]
+partial class ViewController
+{
+    [Action(""Button:"")]
+    partial void Button(Foundation.NSObject sender);
+    [Action(""OnButtonClick2:"")]
+    partial void OnButtonClick2(Foundation.NSObject sender);
+
+    void ReleaseDesignerOutlets()
+    {
+    }
+}";
+const string ViewControllerExplicitActionCSharpExplicit = @"[Register(""ViewController"")]
+partial class ViewController
+{
+    [Action(""Button:"")]
+    partial void Button(Foundation.NSObject sender);
+    [Action(""OnButtonClick2:"")]
+    partial void OnButtonClick2(TestCustomControl.PrimaryButton sender);
+
+    void ReleaseDesignerOutlets()
+    {
+    }
+}";
+	const string PrimaryButtonObjC = @"
+#import <AppKit/AppKit.h>
+#import <Foundation/Foundation.h>
+
+@interface PrimaryButton : NSButton
+@end
+";
 
 	static INamedTypeSymbol CreateTypeSymbol (string name, string? namespaceName)
 	{
@@ -194,4 +293,7 @@ partial class ViewController
 
 		return typeSymbol.Object;
 	}
+
+	static TypeMapping CreateTypeMapping (string name, string? namespaceName) =>
+		new (CreateTypeSymbol (name, namespaceName), name, name, null, false, false, false, null, null, []);
 }

--- a/test/xcsync.tests/Commands/SyncCommandTests.cs
+++ b/test/xcsync.tests/Commands/SyncCommandTests.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.IO.Abstractions.TestingHelpers;
+using Moq;
+using Serilog;
+using xcsync.Commands;
+
+namespace xcsync.tests.Commands;
+
+public class SyncCommandTests {
+
+	[Fact]
+	public void SyncCommand_AddsExplicitTypesOption_WithDefaultFalse ()
+	{
+		var command = new SyncCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var explicitTypes = GetExplicitTypesOption (command);
+		var parseResult = command.Parse ([]);
+
+		Assert.Equal (Strings.Options.ExplicitTypesDescription, explicitTypes.Description);
+		Assert.Contains ("-e", explicitTypes.Aliases);
+		Assert.False (parseResult.CommandResult.GetValueForOption (explicitTypes));
+	}
+
+	[Theory]
+	[InlineData ("--explicit-types")]
+	[InlineData ("-e")]
+	public void SyncCommand_ParsesExplicitTypesAliases (string alias)
+	{
+		var command = new SyncCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var explicitTypes = GetExplicitTypesOption (command);
+		var parseResult = command.Parse ([alias]);
+
+		Assert.True (parseResult.CommandResult.GetValueForOption (explicitTypes));
+	}
+
+	static Option<bool> GetExplicitTypesOption (SyncCommand command) =>
+		Assert.IsType<Option<bool>> (Assert.Single (command.Options.Where (option => option.Aliases.Contains ("--explicit-types"))));
+}

--- a/test/xcsync.tests/Commands/WatchCommandTests.cs
+++ b/test/xcsync.tests/Commands/WatchCommandTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.IO.Abstractions.TestingHelpers;
+using Moq;
+using Serilog;
+using xcsync.Commands;
+
+namespace xcsync.tests.Commands;
+
+public class WatchCommandTests {
+
+	[Fact]
+	public void WatchCommand_AddsIncrementalOption_WithDefaultFalse ()
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var incremental = GetIncrementalOption (command);
+		var parseResult = command.Parse ([]);
+
+		Assert.Equal (Strings.Options.IncrementalDescription, incremental.Description);
+		Assert.Contains ("-i", incremental.Aliases);
+		Assert.False (parseResult.CommandResult.GetValueForOption (incremental));
+	}
+
+	[Fact]
+	public void WatchCommand_AddsExplicitTypesOption_WithDefaultFalse ()
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var explicitTypes = GetExplicitTypesOption (command);
+		var parseResult = command.Parse ([]);
+
+		Assert.Equal (Strings.Options.ExplicitTypesDescription, explicitTypes.Description);
+		Assert.Contains ("-e", explicitTypes.Aliases);
+		Assert.False (parseResult.CommandResult.GetValueForOption (explicitTypes));
+	}
+
+	[Theory]
+	[InlineData ("--incremental")]
+	[InlineData ("-i")]
+	public void WatchCommand_ParsesIncrementalAliases (string alias)
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var incremental = GetIncrementalOption (command);
+		var parseResult = command.Parse ([alias]);
+
+		Assert.True (parseResult.CommandResult.GetValueForOption (incremental));
+	}
+
+	[Theory]
+	[InlineData ("--explicit-types")]
+	[InlineData ("-e")]
+	public void WatchCommand_ParsesExplicitTypesAliases (string alias)
+	{
+		var command = new WatchCommand (new MockFileSystem (), Mock.Of<ILogger> ());
+
+		var explicitTypes = GetExplicitTypesOption (command);
+		var parseResult = command.Parse ([alias]);
+
+		Assert.True (parseResult.CommandResult.GetValueForOption (explicitTypes));
+	}
+
+	static Option<bool> GetIncrementalOption (WatchCommand command) =>
+		Assert.IsType<Option<bool>> (Assert.Single (command.Options.Where (option => option.Aliases.Contains ("--incremental"))));
+
+	static Option<bool> GetExplicitTypesOption (WatchCommand command) =>
+		Assert.IsType<Option<bool>> (Assert.Single (command.Options.Where (option => option.Aliases.Contains ("--explicit-types"))));
+}

--- a/test/xcsync.tests/ContinuousSyncContextTest.cs
+++ b/test/xcsync.tests/ContinuousSyncContextTest.cs
@@ -11,7 +11,39 @@ using xcsync.Workers;
 namespace xcsync.tests;
 
 public class ContinuousSyncContextTest {
-	readonly Mock<IHub> mockHub = new ();
-	readonly ContinuousSyncContext context = new (Mock.Of<IFileSystem> (), Mock.Of<ITypeService> (), "projectPath",
-		"targetDir", "framework", Mock.Of<ILogger> ());
+
+	[Fact]
+	public void ChangeMessage_DefaultsIncrementalToFalse ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.ToXcode, CreateMonitor (), CreateMonitor ());
+
+		Assert.False (message.Incremental);
+	}
+
+	[Fact]
+	public void ChangeMessage_CanEnableIncremental ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.ToXcode, CreateMonitor (), CreateMonitor (), true);
+
+		Assert.True (message.Incremental);
+	}
+
+	[Fact]
+	public void ChangeMessage_DefaultsExplicitTypesToFalse ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.FromXcode, CreateMonitor (), CreateMonitor ());
+
+		Assert.False (message.ExplicitTypes);
+	}
+
+	[Fact]
+	public void ChangeMessage_CanEnableExplicitTypes ()
+	{
+		var message = new ChangeMessage ("1", "/tmp/Test.cs", SyncDirection.FromXcode, CreateMonitor (), CreateMonitor (), ExplicitTypes: true);
+
+		Assert.True (message.ExplicitTypes);
+	}
+
+	static ProjectFileChangeMonitor CreateMonitor () =>
+		new (new MockFileSystem (), Mock.Of<IFileSystemWatcher> (), Mock.Of<ILogger> ());
 }

--- a/test/xcsync.tests/Projects/GenObjcFileTest.cs
+++ b/test/xcsync.tests/Projects/GenObjcFileTest.cs
@@ -120,6 +120,38 @@ public class GenObjcFileTest : Base {
 	}
 
 	[Fact]
+	public void GenerateViewControllerHFile_WithCustomControlOutlet_ImportsCustomControlHeader ()
+	{
+		var nsViewController = new TypeMapping (null, "NSViewController", "NSViewController", null, false, false, false, null, null, ["AppKit", "Foundation"]);
+		var nsType = new TypeMapping (null, "ViewController", "ViewController", nsViewController, false, false, false,
+			[new IBOutlet ("CustomButton", "CustomButton", "PrimaryButton", "PrimaryButton", false)], null, ["AppKit", "Foundation"]) {
+			HeaderReferences = ["PrimaryButton"]
+		};
+
+		var generated = new GenObjcH (nsType).TransformText ();
+
+		const string expected =
+			warning +
+			"""
+			#import <AppKit/AppKit.h>
+			#import <Foundation/Foundation.h>
+			#import "PrimaryButton.h"
+			
+			
+			@interface ViewController : NSViewController {
+				PrimaryButton *_CustomButton;
+			}
+			
+			@property (nonatomic, retain) IBOutlet PrimaryButton *CustomButton;
+			
+			@end
+			
+			""";
+
+		Assert.Equal (expected, generated);
+	}
+
+	[Fact]
 	public void GenerateViewControllerMFile ()
 	{
 		(_, ITypeService typeService) = InitializeProjects ();

--- a/test/xcsync.tests/Projects/GenObjcFileTest.cs
+++ b/test/xcsync.tests/Projects/GenObjcFileTest.cs
@@ -152,6 +152,37 @@ public class GenObjcFileTest : Base {
 	}
 
 	[Fact]
+	public void GenerateViewControllerHFile_WithCustomControlAction_UsesExplicitTypeAndImportsHeader ()
+	{
+		var nsViewController = new TypeMapping (null, "NSViewController", "NSViewController", null, false, false, false, null, null, ["AppKit", "Foundation"]);
+		var nsType = new TypeMapping (null, "ViewController", "ViewController", nsViewController, false, false, false,
+			null, [new IBAction ("OnCancelButtonClicked", "OnCancelButtonClicked", [new IBActionParameter ("sender", null, "PrimaryButton", "PrimaryButton *")])], ["AppKit", "Foundation"]) {
+			HeaderReferences = ["PrimaryButton"]
+		};
+
+		var generated = new GenObjcH (nsType).TransformText ();
+
+		const string expected =
+			warning +
+			"""
+			#import <AppKit/AppKit.h>
+			#import <Foundation/Foundation.h>
+			#import "PrimaryButton.h"
+			
+			
+			@interface ViewController : NSViewController {
+			}
+			
+			- (IBAction)OnCancelButtonClicked:(PrimaryButton *)sender;
+			
+			@end
+			
+			""";
+
+		Assert.Equal (expected, generated);
+	}
+
+	[Fact]
 	public void GenerateViewControllerMFile ()
 	{
 		(_, ITypeService typeService) = InitializeProjects ();
@@ -173,6 +204,32 @@ public class GenObjcFileTest : Base {
 			@synthesize FileLabel = _FileLabel;
 			
 			- (IBAction)UploadButton:(id)sender {
+			}
+			
+			@end
+
+			""";
+
+		Assert.Equal (expected, generated);
+	}
+
+	[Fact]
+	public void GenerateViewControllerMFile_WithCustomControlAction_UsesExplicitType ()
+	{
+		var nsViewController = new TypeMapping (null, "NSViewController", "NSViewController", null, false, false, false, null, null, ["AppKit", "Foundation"]);
+		var nsType = new TypeMapping (null, "ViewController", "ViewController", nsViewController, false, false, false,
+			null, [new IBAction ("OnCancelButtonClicked", "OnCancelButtonClicked", [new IBActionParameter ("sender", null, "PrimaryButton", "PrimaryButton *")])], ["AppKit", "Foundation"]);
+
+		var generated = new GenObjcM (nsType).TransformText ();
+
+		const string expected =
+			warning +
+			"""
+			#import "ViewController.h"
+			
+			@implementation ViewController
+			
+			- (IBAction)OnCancelButtonClicked:(PrimaryButton *)sender {
 			}
 			
 			@end

--- a/test/xcsync.tests/Projects/TypeServiceTest.cs
+++ b/test/xcsync.tests/Projects/TypeServiceTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis;
 using Moq;
 using Serilog;
@@ -69,5 +70,67 @@ public class TypeServiceTest {
 		typeService.AddType (appDelegateDupe);
 		var result = typeService.AddType (appDelegateDupe);
 		Assert.Null (result);
+	}
+
+	[Fact]
+	public void AddCompilation_WithCustomControlAction_AddsHeaderReference ()
+	{
+		var localTypeService = new TypeService (Mock.Of<ILogger> ());
+		var nsObject = new TypeMapping (Mock.Of<INamedTypeSymbol> (), "NSObject", "NSObject", null, false, false, false, null, null, ["Foundation"]);
+		localTypeService.AddType (nsObject);
+		localTypeService.AddType (Mock.Of<INamedTypeSymbol> (), "NSViewController", "NSViewController", nsObject, false, false, false, null, null, ["AppKit", "Foundation"]);
+		localTypeService.AddType (Mock.Of<INamedTypeSymbol> (), "NSButton", "NSButton", nsObject, false, false, false, null, null, ["AppKit", "Foundation"]);
+
+		var compilation = CSharpCompilation.Create ("TestAssembly",
+			[CSharpSyntaxTree.ParseText (
+				"""
+				using Foundation;
+				using AppKit;
+
+				namespace Foundation {
+				public class RegisterAttribute : System.Attribute
+				{
+					public RegisterAttribute (string name) { }
+				}
+
+				public class ActionAttribute : System.Attribute
+				{
+					public ActionAttribute (string name) { }
+				}
+				}
+
+				namespace AppKit {
+				public class NSObject { }
+				public class NSViewController : NSObject { }
+				public class NSButton : NSObject { }
+				}
+
+				namespace TestCustomControl {
+				[Register ("PrimaryButton")]
+				public class PrimaryButton : NSButton { }
+				}
+
+				namespace TestApp {
+				[Register ("ViewController")]
+				public partial class ViewController : NSViewController
+				{
+					[Action ("OnCancelButtonClicked:")]
+					partial void OnCancelButtonClicked (TestCustomControl.PrimaryButton sender);
+				}
+				}
+				""")],
+			[MetadataReference.CreateFromFile (typeof (object).Assembly.Location)]);
+
+		localTypeService.AddCompilation ("macos", compilation);
+
+		var result = localTypeService.QueryTypes (clrType: "ViewController").Single ();
+
+		Assert.NotNull (result);
+		Assert.Contains ("PrimaryButton", result!.HeaderReferences);
+		Assert.NotNull (result.Actions);
+		Assert.Single (result.Actions!);
+		Assert.Single (result.Actions [0].Parameters);
+		Assert.Equal ("PrimaryButton", result.Actions [0].Parameters [0].ClrType);
+		Assert.Equal ("PrimaryButton", result.Actions [0].Parameters [0].ObjCType);
 	}
 }


### PR DESCRIPTION
### Summary
This PR improves how xcsync generates Objective-C / C# interop code and fixes a few related bugs in sync/watch behavior.

The main issue was that generated files were not always correct: some .h files were missing required imports, designer.cs could end up with the wrong namespace, and outlet/action parameter types were sometimes mapped incorrectly when Clang reported pointer-like types such as int*. On top of that, sync/watch gained an explicit types option so generated code can be more predictable when type inference is not enough.

### What changed
- Fixed missing imports in generated .h files.
- Corrected namespace generation in designer.cs.
- Improved outlet/action type mapping, especially for Clang-reported pointer types.
- Added support for an explicit types option in sync.
   Currently all action parameters types converted from XCode to C# were created as NSObject event though in a header file was a different type. It's user unfriendly so I extended with -e option (--explicit-types) not to break compatibility. Valid for sync/watch command

Added and expanded tests around the rewriter, type mapping, sync/watch commands, and generated files.
Issue addressed
The issue was that xcsync could generate code that was incomplete or inconsistent:

imports were sometimes missing from generated header files,
generated designer code could use the wrong namespace,
some action/outlet parameter types were inferred incorrectly,
and users had no way to force explicit generated types when needed.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/243)