### PR TITLE
[ci] Make the whole job use a single .NET installation

### DIFF
--- a/eng/pipelines/templates/buildandtest.yml
+++ b/eng/pipelines/templates/buildandtest.yml
@@ -24,9 +24,21 @@ parameters:
 
 steps:
 
-  - task: UseDotNet@2
-    inputs: 
-      useGlobalJson: true
+  # Note: don't use the UseDotNet@2 task to install the .NET SDK.
+  #
+  # It honors global.json's "rollForward" policy, so it may install a different SDK than the
+  # exact version Arcade requires (global.json's "tools.dotnet"). When that happens Arcade
+  # installs a second SDK into $(Build.SourcesDirectory)/.dotnet, while DOTNET_ROOT keeps
+  # pointing at the one from the tool cache. The workloads then get installed into one SDK
+  # while Roslyn's MSBuildWorkspace (which resolves the SDK via DOTNET_ROOT) uses the other,
+  # so the design-time builds in the tests resolve no references and find no types.
+  #
+  # Instead let the build script install the SDK, and point every step at that single
+  # installation, so that the build, the workloads and the tests all use the same SDK.
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=DOTNET_INSTALL_DIR]$(Build.SourcesDirectory)/.dotnet"
+      Write-Host "##vso[task.setvariable variable=DOTNET_ROOT]$(Build.SourcesDirectory)/.dotnet"
+    displayName: Use a single .NET installation
 
   - ${{ if ne(parameters.isWindows, 'true') }}:
     - script: ${{ parameters.buildScript }}
@@ -49,16 +61,11 @@ steps:
 
   - ${{ if or(ne(parameters.runAsPublic, 'true'), ne(parameters.runHelixTests, 'true')) }}:
     - pwsh: |
-        # Get .NET SDK Version from global.json
-        $globalJson = Get-Content -Path "global.json" -Raw | ConvertFrom-Json
-        $workloadSetVersion = "${$jsonContent.sdk.version}.0"
-
-        # Update/install workloads to the workload set
-        dotnet workload update --source https://api.nuget.org/v3/index.json --version $workloadSetVersion
-        dotnet workload install macos ios maccatalyst tvos maui --source https://api.nuget.org/v3/index.json --version 8.0.402.0 # Neccessary for tests
+        # Install the workloads into the same .NET SDK that the build and the tests use.
+        ${{ parameters.dotnetScript }} workload install macos ios maccatalyst tvos maui --source https://api.nuget.org/v3/index.json --version 8.0.402.0 # Neccessary for tests
 
         # List installed workloads
-        dotnet workload list        
+        ${{ parameters.dotnetScript }} workload list
       displayName: Install workloads
 
     - ${{ if ne(parameters.isWindows, 'true') }}:

--- a/src/xcsync/Projects/ClrProject.cs
+++ b/src/xcsync/Projects/ClrProject.cs
@@ -20,6 +20,10 @@ class ClrProject (IFileSystem fileSystem, ILogger logger, ITypeService typeServi
 			{"TargetFrameworks", Framework}
 		});
 
+		// Without this, failures to load the project (missing workloads, design-time build errors, ...)
+		// are silent, and the only symptom is that no types are found in the project.
+		workspace.WorkspaceFailed += (_, e) => Logger.Warning (Strings.ClrProject.LoadError (RootPath, e.Diagnostic.Message));
+
 		var project = await workspace.OpenProjectAsync (RootPath).ConfigureAwait (false);
 
 		try {

--- a/src/xcsync/Projects/TypeService.cs
+++ b/src/xcsync/Projects/TypeService.cs
@@ -161,6 +161,9 @@ class TypeService (ILogger Logger) : ITypeService {
 		if (namespaces is null)
 			return;
 
+		if (!namespaces.Any ())
+			Logger.Warning (Strings.TypeService.NoTypesFound (compilation.AssemblyName!));
+
 		foreach (var ns in namespaces) {
 			foreach (var type in ns.GetTypeMembers ().Where (xcSync.IsNsoDerived)) {
 				var nsType = ConvertToTypeMapping (targetPlatform, type);

--- a/src/xcsync/Resources/Strings.Designer.cs
+++ b/src/xcsync/Resources/Strings.Designer.cs
@@ -97,6 +97,7 @@ static class Strings {
 		internal static string MappingUpdateFailed (string clrType, string objCType) => string.Format (Resources.Strings.TypeService_MappingUpdateFailed, clrType, objCType);
 		internal static string MissingAssemblyName => Resources.Strings.TypeService_MissingAssemblyName;
 		internal static string DuplicateCompilation (string assemblyName) => string.Format (Resources.Strings.TypeService_DuplicateCompilation, assemblyName);
+		internal static string NoTypesFound (string assemblyName) => string.Format (Resources.Strings.TypeService_NoTypesFound, assemblyName);
 		internal static string CompilationNotFound (string assemblyName) => string.Format (Resources.Strings.TypeService_CompilationNotFound, assemblyName);
 		internal static string TypeNotFound (string typeName) => string.Format (Resources.Strings.TypeService_TypeNotFound, typeName);
 		internal static string SyntaxRootNotFound (string typeName) => string.Format (Resources.Strings.TypeService_SyntaxRootNotFound, typeName);
@@ -109,6 +110,7 @@ static class Strings {
 		internal static string NotSupportedException (string path) => string.Format (Resources.Strings.ClrProject_NotSupportedException, path);
 		internal static string InvalidOperationException (string path, string message) => string.Format (Resources.Strings.ClrProject_InvalidOperationException, path, message);
 		internal static string CompilationError (string path, string message) => string.Format (Resources.Strings.ClrProject_CompilationError, path, message);
+		internal static string LoadError (string path, string message) => string.Format (Resources.Strings.ClrProject_LoadError, path, message);
 		internal static string InvalidOperationError (string path, string message) => string.Format (Resources.Strings.ClrProject_InvalidOperationError, path, message);
 		internal static string UnexpectedError (string path, string message) => string.Format (Resources.Strings.ClrProject_UnexpectedError, path, message);
 	}

--- a/src/xcsync/Resources/Strings.resx
+++ b/src/xcsync/Resources/Strings.resx
@@ -367,6 +367,10 @@
         <value>The compilation for {0} has already been added, ignoring this instance.</value>
         <comment>{0} is the name of the assembly</comment>
     </data>	
+    <data name="TypeService.NoTypesFound" xml:space="preserve">
+        <value>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</value>
+        <comment>{0} is the name of the assembly</comment>
+    </data>
     <data name="TypeService.TypeNotFound" xml:space="preserve">
         <value>The {0} type could not be located for synchronization.</value>
         <comment>{0} is the name of the type</comment>
@@ -400,6 +404,10 @@
 	<data name="ClrProject.InvalidOperationException" xml:space="preserve">
         <value>Compilation errors detected in project '{0}': {1}}</value>
         <comment>{0} is the path to the .NET project, {1} is the list of error messages</comment>
+	</data>
+	<data name="ClrProject.LoadError" xml:space="preserve">
+        <value>Error loading project '{0}' : {1}</value>
+        <comment>{0} is the path to the .NET project, {1} is the error message</comment>
 	</data>
 	<data name="ClrProject.CompilationError" xml:space="preserve">
         <value>Compilation error in project '{0}' : {1}</value>

--- a/src/xcsync/Resources/xlf/Strings.cs.xlf
+++ b/src/xcsync/Resources/xlf/Strings.cs.xlf
@@ -57,6 +57,11 @@
         <target state="translated">V projektu {0} byly zjištěny chyby kompilace: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Kompilace se pro aktuální projekt {0} nepodporuje.</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">Kompilace nemá parametr AssemblyName. Je to pravděpodobně proto, že je dynamická a nepodporovaná.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.de.xlf
+++ b/src/xcsync/Resources/xlf/Strings.de.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Kompilierungsfehler im Projekt „{0}“: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Die Kompilierung wird für das aktuelle Projekt „{0}“ nicht unterstützt.</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">Die Kompilierung weist keinen AssemblyName auf. Dies ist möglicherweise darauf zurückzuführen, dass sie dynamisch ist und nicht unterstützt wird.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.es.xlf
+++ b/src/xcsync/Resources/xlf/Strings.es.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Errores de compilación detectados en el proyecto "{0}": {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Compilación no admitida para el proyecto actual "{0}"</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">La compilación no tiene un AssemblyName, posiblemente porque es dinámico y no se admite.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.fr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.fr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Erreurs de compilation détectées dans le projet « {0} » : {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Compilation non prise en charge pour le projet actuel « {0} »</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">La compilation n’a pas de AssemblyName, peut-être parce qu’elle est dynamique et n’est pas prise en charge.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.it.xlf
+++ b/src/xcsync/Resources/xlf/Strings.it.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Errori di compilazione rilevati nel progetto "{0}": {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Compilazione non supportata per il progetto corrente "{0}"</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">La compilazione non contiene un oggetto AssemblyName, probabilmente perché è dinamico e non è supportato.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.ja.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ja.xlf
@@ -57,6 +57,11 @@
         <target state="translated">プロジェクト '{0}' でコンパイル エラーが検出されました: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">現在のプロジェクト '{0}' ではコンパイルがサポートされていません</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">コンパイルに AssemblyName がありません。これは動的であり、サポートされていないことが原因である可能性があります。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.ko.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ko.xlf
@@ -57,6 +57,11 @@
         <target state="translated">'{0}' 프로젝트에서 컴파일 오류가 검색되었습니다. {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">현재 프로젝트 '{0}'에 대해 컴파일이 지원되지 않습니다.</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">컴파일에 AssemblyName이 없습니다. 동적이며 지원되지 않기 때문일 수 있습니다.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.pl.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pl.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Wykryto błędy kompilacji w projekcie „{0}”: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Kompilacja nie jest obsługiwana dla bieżącego projektu „{0}”</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">Kompilacja nie ma elementu AssemblyName, prawdopodobnie dlatego, że jest dynamiczna i nieobsługiwana.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/xcsync/Resources/xlf/Strings.pt-BR.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Erros de compilação detectados no projeto "{0}": {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Não há suporte para compilação para o projeto atual "{0}"</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">A compilação não tem um AssemblyName, possivelmente porque é dinâmica e não tem suporte.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.ru.xlf
+++ b/src/xcsync/Resources/xlf/Strings.ru.xlf
@@ -57,6 +57,11 @@
         <target state="translated">Обнаружены ошибки компиляции в проекте "{0}" : {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Компиляция не поддерживается для текущего проекта  "{0}"</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">Компиляция не содержит AssemblyName. Возможная причина: она является динамической и не поддерживается.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.tr.xlf
+++ b/src/xcsync/Resources/xlf/Strings.tr.xlf
@@ -57,6 +57,11 @@
         <target state="translated">'{0}' projesinde derleme hataları algılandı: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">Geçerli '{0}' projesi için derleme desteklenmiyor</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">Derlemenin bir AssemblyName'i yok, bunun nedeni muhtemelen dinamik olması ve desteklenmemesidir.</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hans.xlf
@@ -57,6 +57,11 @@
         <target state="translated">在项目 "{0}" 中检测到编译错误: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">当前项目 "{0}" 不支持编译</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">编译没有 AssemblyName，可能是因为它是动态的且不受支持。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>

--- a/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/xcsync/Resources/xlf/Strings.zh-Hant.xlf
@@ -57,6 +57,11 @@
         <target state="translated">在專案 '{0}' 中偵測到編譯錯誤: {1}}</target>
         <note>{0} is the path to the .NET project, {1} is the list of error messages</note>
       </trans-unit>
+      <trans-unit id="ClrProject.LoadError">
+        <source>Error loading project '{0}' : {1}</source>
+        <target state="new">Error loading project '{0}' : {1}</target>
+        <note>{0} is the path to the .NET project, {1} is the error message</note>
+      </trans-unit>
       <trans-unit id="ClrProject.NotSupportedException">
         <source>Compilation not supported for current project  '{0}'</source>
         <target state="translated">目前專案 '{0}' 不支援編譯</target>
@@ -338,6 +343,11 @@
         <source>The compilation does not have an AssemblyName, possibly because it is dynamic, and unsupported.</source>
         <target state="translated">編譯沒有 AssemblyName，可能是因為它是動態且不受支援。</target>
         <note />
+      </trans-unit>
+      <trans-unit id="TypeService.NoTypesFound">
+        <source>No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</source>
+        <target state="new">No NSObject derived types were found in {0}. Verify that the workloads required by the project are installed.</target>
+        <note>{0} is the name of the assembly</note>
       </trans-unit>
       <trans-unit id="TypeService.SyntaxRootNotFound">
         <source>The {0} type could not be synchronized due to missing symbol information.</source>


### PR DESCRIPTION
All CI runs since the hosted agent image was refreshed fail 25 tests, all with the same symptom: no types are found in the .NET project, so no Objective-C files are generated (`Expected: ["AlsoNoSkip", ...] Actual: []`).

The cause is that there are two .NET SDKs on the agent:

* The `UseDotNet@2` task honors global.json's `rollForward: major` policy. A newer version of the task started resolving that to 8.0.424 instead of the 8.0.415 that global.json's `sdk.version` asks for, and it installs it into the hosted tool cache and points `DOTNET_ROOT` at it.
* Arcade requires exactly the version from global.json's `tools.dotnet` (8.0.415), doesn't find it in the tool cache anymore, and installs a second SDK into `$(Build.SourcesDirectory)/.dotnet`.

The workloads end up in one of them, while Roslyn's `MSBuildWorkspace` - which is what the tests use to load the .NET projects - resolves the SDK via `DOTNET_ROOT` and thus uses the other one. Without the macOS/iOS workloads the design-time build resolves no references, so no NSObject-derived types are found.

This is confirmed by the `tests.binlog` published by the failing builds, which records `DOTNET_ROOT = /Users/runner/hostedtoolcache/dotnet` while `DOTNET_HOST_PATH = /Users/runner/work/1/s/.dotnet/dotnet`.

Verified locally with an A/B run where only `DOTNET_ROOT` differs: with it pointing at an SDK without the workloads, `xcsync generate` produces 4 files (no `.h`/`.m` at all) and `DotnetTest.GetTypes` fails exactly like on CI; pointing it at the SDK with the workloads produces all 19 files and the test passes.

Fix: drop `UseDotNet@2` and pin both `DOTNET_INSTALL_DIR` and `DOTNET_ROOT` to the installation Arcade creates, so the build, the workloads and the tests all use the same SDK. Also install the workloads with the build script's dotnet instead of whichever `dotnet` happens to be on PATH, and remove the `dotnet workload update` call: it referenced an undefined `$jsonContent` variable and always failed with "Workload update failed: Index was outside the bounds of the array" (it was already broken in the runs that were green).

Additionally, log a warning when a project loads but no NSObject-derived types are found, and when the workspace fails to load a project. Both of these were entirely silent, which is why this failure showed up as an empty Xcode project with nothing in the logs.

🤖 Pull request created by Copilot

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/253)