### PR TITLE
Use supported Windows pipeline image

### DIFF
--- a/eng/pipelines/azure-pipelines.yml
+++ b/eng/pipelines/azure-pipelines.yml
@@ -104,7 +104,7 @@ extends:
         justificationForDisabling: 'see https://portal.microsofticm.com/imp/v3/incidents/incident/482258316/summary'
       sourceAnalysisPool:
         name: $(DncEngInternalBuildPool)
-        image: windows.vs2022preview.amd64
+        image: windows.vs2022.amd64
         os: windows
       tsa:
         enabled: true
@@ -195,7 +195,7 @@ extends:
 
               pool:
                 name: NetCore1ESPool-Internal
-                image: windows.vs2022preview.amd64
+                image: windows.vs2022.amd64
                 os: windows
                             
               variables:


### PR DESCRIPTION
Replace the retired VS 2022 preview image in the SDL and Windows signing jobs with the supported VS 2022 image.


Copilot-Session: cfbdfefc-a2c1-4e92-a8f2-f41b71fd6e5a
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/254)