### PR TITLE
Bump .NET and NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,7 @@
     <PackageVersion Include="NuGet.Frameworks" Version="$(NuGetFrameworksPackageVersion)" />
     <PackageVersion Include="System.Text.Json" Version="$(SystemTextJsonPackageVersion)" />
     <PackageVersion Include="System.Formats.Asn1" Version="$(SystemFormatsAsn1PackageVersion)" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="$(SystemSecurityCryptographyXmlPackageVersion)" />
     <!-- ClangSharp -->
     <PackageVersion Include="clangsharp" Version="$(ClangSharpPackageVersion)" />
     <PackageVersion Include="libClang.runtime.osx-arm64" Version="$(libClangRuntimeOsxArm64PackageVersion)" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -27,9 +27,6 @@
     <packageSource key="dotnet8">
       <package pattern="*" />
     </packageSource>
-    <packageSource key="dotnet-libraries">
-      <package pattern="System.CommandLine" />
-    </packageSource>
     <packageSource key="dotnet-eng">
       <package pattern="*" />
     </packageSource>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -12,36 +12,37 @@
     <!-- Bump packages using link below -->
     <!-- For non-MSFT packages, use `New or non-Microsoft package` even when updating..-->
     <!-- https://github.com/dotnet/arcade/blob/main/Documentation/MirroringPackages.md -->
-    <MarillePackageVersion>0.5.3</MarillePackageVersion>
-    <MicrosoftBuildPackageVersion>17.11.4</MicrosoftBuildPackageVersion>
+    <MarillePackageVersion>0.5.8</MarillePackageVersion>
+    <MicrosoftBuildPackageVersion>17.11.48</MicrosoftBuildPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.9.1</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftCodeAnalysisPackageVersion>4.14.0</MicrosoftCodeAnalysisPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>9.0.0</MicrosoftExtensionsLoggingPackageVersion>
-    <MicrosoftNETSdkPackageVersion>9.0.100-rc.2.24420.21</MicrosoftNETSdkPackageVersion>
-    <SerilogPackageVersion>4.0.0</SerilogPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>9.0.19</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftNETSdkPackageVersion>9.0.318-servicing.26418.16</MicrosoftNETSdkPackageVersion>
+    <SerilogPackageVersion>4.4.0</SerilogPackageVersion>
     <SerilogEnrichersThreadPackageVersion>4.0.0</SerilogEnrichersThreadPackageVersion>
     <SerilogExpressionsPackageVersion>4.0.0</SerilogExpressionsPackageVersion>
     <SerilogSinksConsolePackageVersion>5.0.1</SerilogSinksConsolePackageVersion>
     <SerilogSinksDebugPackageVersion>2.0.0</SerilogSinksDebugPackageVersion>
-    <SystemCommandLinePackageVersion>2.0.0-beta4.22272.1</SystemCommandLinePackageVersion>
-    <TestableIOSystemIOAbstractionsPackageVersion>21.0.2</TestableIOSystemIOAbstractionsPackageVersion>
-    <TestableIOSystemIOAbstractionsWrappersPackageVersion>21.0.2</TestableIOSystemIOAbstractionsWrappersPackageVersion>
+    <SystemCommandLinePackageVersion>2.0.11</SystemCommandLinePackageVersion>
+    <TestableIOSystemIOAbstractionsPackageVersion>21.3.1</TestableIOSystemIOAbstractionsPackageVersion>
+    <TestableIOSystemIOAbstractionsWrappersPackageVersion>21.3.1</TestableIOSystemIOAbstractionsWrappersPackageVersion>
     <TestableIOSystemIOAbstractionsAnalyzersPackageVersion>2022.0.0</TestableIOSystemIOAbstractionsAnalyzersPackageVersion>
-    <NuGetFrameworksPackageVersion>6.11.1</NuGetFrameworksPackageVersion>
-    <SystemTextJsonPackageVersion>9.0.2</SystemTextJsonPackageVersion>
-    <SystemFormatsAsn1PackageVersion>9.0.2</SystemFormatsAsn1PackageVersion>
+    <NuGetFrameworksPackageVersion>6.14.3</NuGetFrameworksPackageVersion>
+    <SystemTextJsonPackageVersion>9.0.19</SystemTextJsonPackageVersion>
+    <SystemFormatsAsn1PackageVersion>9.0.19</SystemFormatsAsn1PackageVersion>
+    <SystemSecurityCryptographyXmlPackageVersion>8.0.4</SystemSecurityCryptographyXmlPackageVersion>
     <!-- ClangSharp -->
-    <clangsharpPackageVersion>18.1.0</clangsharpPackageVersion>
+    <clangsharpPackageVersion>18.1.0.4</clangsharpPackageVersion>
     <libClangRuntimeOsxArm64PackageVersion>18.1.3</libClangRuntimeOsxArm64PackageVersion>
     <libClangSharpRuntimeOsxArm64PackageVersion>18.1.3.1</libClangSharpRuntimeOsxArm64PackageVersion>
     <libClangRuntimeOsxX64PackageVersion>18.1.3</libClangRuntimeOsxX64PackageVersion>
     <libClangSharpRuntimeOsxX64PackageVersion>18.1.3.1</libClangSharpRuntimeOsxX64PackageVersion>
     <!-- Test Packages -->
     <SerilogSinksXunitPackageVersion>3.0.5</SerilogSinksXunitPackageVersion>
-    <SystemLinqAsyncPackageVersion>6.0.1</SystemLinqAsyncPackageVersion>
+    <SystemLinqAsyncPackageVersion>6.0.3</SystemLinqAsyncPackageVersion>
     <CoverletCollectorPackageVersion>6.0.4</CoverletCollectorPackageVersion>
-    <TestableIOSystemIOAbstractionsTestingHelpers>21.0.2</TestableIOSystemIOAbstractionsTestingHelpers>
-    <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.25230.1</MicrosoftDotNetXUnitExtensionsPackageVersion>
+    <TestableIOSystemIOAbstractionsTestingHelpers>21.3.1</TestableIOSystemIOAbstractionsTestingHelpers>
+    <MicrosoftDotNetXUnitExtensionsPackageVersion>8.0.0-beta.26431.7</MicrosoftDotNetXUnitExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="LockedPackageVersions">
     <!--

--- a/global.json
+++ b/global.json
@@ -1,16 +1,16 @@
 {
   "sdk": {
-    "version": "8.0.415",
+    "version": "8.0.420",
     "rollForward": "major",
     "allowPrerelease": true
   },
   "tools": {
-    "dotnet": "8.0.415"
+    "dotnet": "8.0.420"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.26423.4",
-    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.25230.1",
-    "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.25230.1",
-    "Microsoft.Build.NoTargets": "3.7.56"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.26431.7",
+    "Microsoft.DotNet.Helix.Sdk": "8.0.0-beta.26431.7",
+    "Microsoft.DotNet.SharedFramework.Sdk": "8.0.0-beta.26431.7",
+    "Microsoft.Build.NoTargets": "3.7.134"
   }
 }

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -36,20 +36,20 @@ class BaseCommand<T> : Command {
 	protected string TargetPlatform => TryGetTargetPlatform (Tfm, out string targetPlatform) ? targetPlatform : string.Empty;
 	protected readonly IFileSystem fileSystem;
 
-	protected Option<string> project = new (
-		["--project", "-p"],
-		description: Strings.Options.ProjectDescription,
-		getDefaultValue: () => ".");
+	protected Option<string> project = new ("--project", "-p") {
+		Description = Strings.Options.ProjectDescription,
+		DefaultValueFactory = _ => ".",
+	};
 
-	protected Option<string> tfm = new (
-		["--target-framework-moniker", "-tfm"],
-		description: Strings.Options.TfmDescription,
-		getDefaultValue: () => string.Empty);
+	protected Option<string> tfm = new ("--target-framework-moniker", "-tfm") {
+		Description = Strings.Options.TfmDescription,
+		DefaultValueFactory = _ => string.Empty,
+	};
 
-	protected Option<string> target = new (
-		["--target", "-t"],
-		description: Strings.Options.TargetDescription,
-		getDefaultValue: () => $"$(IntermediateOutputPath){Path.DirectorySeparatorChar}{DefaultXcodeOutputFolder}");
+	protected Option<string> target = new ("--target", "-t") {
+		Description = Strings.Options.TargetDescription,
+		DefaultValueFactory = _ => $"$(IntermediateOutputPath){Path.DirectorySeparatorChar}{DefaultXcodeOutputFolder}",
+	};
 
 	public BaseCommand (IFileSystem fileSystem, ILogger logger, string name, string description) : base (name, description)
 	{
@@ -65,17 +65,17 @@ class BaseCommand<T> : Command {
 
 	protected virtual void AddOptions ()
 	{
-		Add (project);
-		Add (tfm);
-		Add (target);
+		Options.Add (project);
+		Options.Add (tfm);
+		Options.Add (target);
 	}
 
 	protected virtual void AddValidators ()
 	{
-		AddValidator ((result) => {
+		Validators.Add ((result) => {
 
 			if (!RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
-				result.ErrorMessage = Strings.Errors.Validation.InvalidOS;
+				result.AddError (Strings.Errors.Validation.InvalidOS);
 				return;
 			}
 
@@ -87,7 +87,8 @@ class BaseCommand<T> : Command {
 			ProjectPath = validation.ProjectPath;
 			Tfm = validation.Tfm;
 			TargetPath = validation.TargetPath;
-			result.ErrorMessage = validation.Error;
+			if (!string.IsNullOrEmpty (validation.Error))
+				result.AddError (validation.Error);
 		});
 	}
 
@@ -96,9 +97,9 @@ class BaseCommand<T> : Command {
 	internal ValidationResult ValidateCommand (CommandResult result)
 	{
 		string error;
-		var projectPath = result.GetValueForOption (project) ?? string.Empty;
-		var targetPath = result.GetValueForOption (target) ?? string.Empty;
-		var moniker = result.GetValueForOption (tfm) ?? string.Empty;
+		var projectPath = result.GetValue (project) ?? string.Empty;
+		var targetPath = result.GetValue (target) ?? string.Empty;
+		var moniker = result.GetValue (tfm) ?? string.Empty;
 
 		(error, string newProjectPath) = TryValidateProjectPath (projectPath);
 		if (!string.IsNullOrEmpty (error)) { return new ValidationResult (projectPath, moniker, targetPath, error); }

--- a/src/xcsync/Commands/BaseCommand.cs
+++ b/src/xcsync/Commands/BaseCommand.cs
@@ -98,7 +98,9 @@ class BaseCommand<T> : Command {
 	{
 		string error;
 		var projectPath = result.GetValue (project) ?? string.Empty;
-		var targetPath = result.GetValue (target) ?? string.Empty;
+		var targetPath = result.GetValue (target);
+		if (string.IsNullOrEmpty (targetPath))
+			targetPath = $"$(IntermediateOutputPath){Path.DirectorySeparatorChar}{DefaultXcodeOutputFolder}";
 		var moniker = result.GetValue (tfm) ?? string.Empty;
 
 		(error, string newProjectPath) = TryValidateProjectPath (projectPath);

--- a/src/xcsync/Commands/GenerateCommand.cs
+++ b/src/xcsync/Commands/GenerateCommand.cs
@@ -12,7 +12,7 @@ class GenerateCommand : XcodeCommand<GenerateCommand> {
 
 	public GenerateCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "generate", Strings.Commands.GenerateDescription)
 	{
-		this.SetHandler (Execute);
+		SetAction (_ => Execute ());
 	}
 
 	public async Task Execute ()

--- a/src/xcsync/Commands/SharedOptions.cs
+++ b/src/xcsync/Commands/SharedOptions.cs
@@ -7,18 +7,18 @@ namespace xcsync.Commands;
 
 static class SharedOptions {
 	public static readonly Option<Verbosity> Verbose =
-		new (["--verbosity", "-v"],
-			getDefaultValue: () => Verbosity.Normal) {
-			IsRequired = false,
+		new ("--verbosity", "-v") {
 			Arity = ArgumentArity.ZeroOrOne,
-			Description = Strings.Options.VerbosityDescription
+			Description = Strings.Options.VerbosityDescription,
+			DefaultValueFactory = _ => Verbosity.Normal,
+			Recursive = true,
 		};
 
 	public static readonly Option<string> DotnetPath =
-		new (["--dotnet-path", "-d"],
-			getDefaultValue: () => string.Empty) {
-			IsRequired = false,
+		new ("--dotnet-path", "-d") {
 			Arity = ArgumentArity.ZeroOrOne,
-			Description = Strings.Options.DotnetPathDescription
+			Description = Strings.Options.DotnetPathDescription,
+			DefaultValueFactory = _ => string.Empty,
+			Recursive = true,
 		};
 }

--- a/src/xcsync/Commands/SyncCommand.cs
+++ b/src/xcsync/Commands/SyncCommand.cs
@@ -11,7 +11,7 @@ namespace xcsync.Commands;
 class SyncCommand : BaseCommand<SyncCommand> {
 	public SyncCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "sync", Strings.Commands.SyncDescription)
 	{
-		this.SetHandler (Execute);
+		SetAction (_ => Execute ());
 	}
 
 	public async Task Execute ()

--- a/src/xcsync/Commands/WatchCommand.cs
+++ b/src/xcsync/Commands/WatchCommand.cs
@@ -14,10 +14,10 @@ class WatchCommand : XcodeCommand<WatchCommand> {
 
 	public WatchCommand (IFileSystem fileSystem, ILogger logger) : base (fileSystem, logger, "watch", Strings.Commands.WatchDescription)
 	{
-		this.SetHandler (Execute, project, target, tfm, force, open);
+		SetAction (_ => Execute ());
 	}
 
-	public async Task Execute (string project, string target, string tfm, bool force, bool open)
+	public async Task Execute ()
 	{
 		using var cts = new CancellationTokenSource ();
 
@@ -31,7 +31,7 @@ class WatchCommand : XcodeCommand<WatchCommand> {
 
 		LogInformation (Strings.Watch.HeaderInformation (ProjectPath, TargetPath, Tfm));
 
-		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, open, force);
+		var sync = new ContinuousSyncContext (fileSystem, new TypeService (Logger!), ProjectPath, TargetPath, Tfm, Logger!, Open, Force);
 
 		// Start an asynchronous task
 		var xcsyncTask = Task.Run (async () => {

--- a/src/xcsync/Commands/XcSyncCommand.cs
+++ b/src/xcsync/Commands/XcSyncCommand.cs
@@ -18,13 +18,13 @@ class XcSyncCommand : RootCommand {
 		Logger = logger ?? xcSync.Logger!
 			.ForContext ("SourceContext", typeof (XcSyncCommand).Name.Replace ("Command", string.Empty).ToLowerInvariant ());
 
-		AddGlobalOption (SharedOptions.Verbose);
-		AddGlobalOption (SharedOptions.DotnetPath);
+		Options.Add (SharedOptions.Verbose);
+		Options.Add (SharedOptions.DotnetPath);
 
-		SharedOptions.Verbose.AddValidator (result => {
+		SharedOptions.Verbose.Validators.Add (result => {
 			try {
-				var value = result.GetValueForOption (SharedOptions.Verbose);
-				if (!result.IsImplicit && result.Tokens.Count == 0) {
+				var value = result.GetValueOrDefault<Verbosity> ();
+				if (result.Tokens.Count == 0) {
 					value = Verbosity.Normal;
 				}
 				xcSync.LogLevelSwitch.MinimumLevel = value switch {
@@ -36,17 +36,17 @@ class XcSyncCommand : RootCommand {
 					_ => LogEventLevel.Information,
 				};
 			} catch (InvalidOperationException) {
-				result.ErrorMessage = Strings.Errors.Validation.InvalidVerbosity;
+				result.AddError (Strings.Errors.Validation.InvalidVerbosity);
 			}
 		});
 
-		SharedOptions.DotnetPath.AddValidator (result => {
-			xcSync.DotnetPath = result.GetValueForOption (SharedOptions.DotnetPath) ?? string.Empty;
+		SharedOptions.DotnetPath.Validators.Add (result => {
+			xcSync.DotnetPath = result.GetValueOrDefault<string> () ?? string.Empty;
 			Logger?.Debug (Strings.Base.DotnetPath (xcSync.DotnetPath));
 		});
 
-		AddCommand (new GenerateCommand (fileSystem, Logger));
-		AddCommand (new SyncCommand (fileSystem, Logger));
-		AddCommand (new WatchCommand (fileSystem, Logger));
+		Subcommands.Add (new GenerateCommand (fileSystem, Logger));
+		Subcommands.Add (new SyncCommand (fileSystem, Logger));
+		Subcommands.Add (new WatchCommand (fileSystem, Logger));
 	}
 }

--- a/src/xcsync/Commands/XcodeCommand.cs
+++ b/src/xcsync/Commands/XcodeCommand.cs
@@ -12,15 +12,13 @@ class XcodeCommand<T> : BaseCommand<T> {
 	protected bool Force { get; private set; }
 	protected bool Open { get; private set; }
 
-	protected Option<bool> force = new (
-		["--force", "-f"],
-		description: Strings.Options.ForceDescription,
-		getDefaultValue: () => false);
+	protected Option<bool> force = new ("--force", "-f") {
+		Description = Strings.Options.ForceDescription,
+	};
 
-	protected Option<bool> open = new (
-		["--open", "-o"],
-		description: Strings.Options.OpenDescription,
-		getDefaultValue: () => false);
+	protected Option<bool> open = new ("--open", "-o") {
+		Description = Strings.Options.OpenDescription,
+	};
 
 	public XcodeCommand (IFileSystem fileSystem, ILogger logger, string name, string description) : base (fileSystem, logger, name, description)
 	{ }
@@ -28,15 +26,15 @@ class XcodeCommand<T> : BaseCommand<T> {
 	protected override void AddOptions ()
 	{
 		base.AddOptions ();
-		Add (force);
-		Add (open);
+		Options.Add (force);
+		Options.Add (open);
 	}
 
 	protected override void AddValidators ()
 	{
-		AddValidator ((result) => {
-			Force = result.GetValueForOption (force);
-			Open = result.GetValueForOption (open);
+		Validators.Add ((result) => {
+			Force = result.GetValue (force);
+			Open = result.GetValue (open);
 		});
 		base.AddValidators ();
 	}

--- a/src/xcsync/Workers/BaseWorker.cs
+++ b/src/xcsync/Workers/BaseWorker.cs
@@ -12,6 +12,8 @@ public abstract class BaseWorker<T> : IWorker<T>, IErrorWorker<T> where T : stru
 
 	public abstract Task ConsumeAsync (T message, Exception exception, CancellationToken token = default);
 
+	public virtual Task OnChannelClosedAsync (string topicName, CancellationToken token = default) => Task.CompletedTask;
+
 	public virtual void Dispose () { }
 
 	public virtual ValueTask DisposeAsync () => ValueTask.CompletedTask;

--- a/src/xcsync/xcSync.cs
+++ b/src/xcsync/xcSync.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Parsing;
 using System.Diagnostics.CodeAnalysis;
 using System.IO.Abstractions;
 using Microsoft.Build.Locator;
@@ -36,11 +34,7 @@ static class xcSync {
 
 		RegisterMSBuild ();
 
-		var parser = new CommandLineBuilder (new XcSyncCommand (FileSystem))
-			.UseDefaults ()
-			.Build ();
-
-		return await parser.InvokeAsync (args).ConfigureAwait (false);
+		return await new XcSyncCommand (FileSystem).Parse (args).InvokeAsync ().ConfigureAwait (false);
 	}
 
 	static void RegisterMSBuild ()

--- a/src/xcsync/xcsync.csproj
+++ b/src/xcsync/xcsync.csproj
@@ -78,6 +78,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="System.Formats.Asn1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Microsoft.Extensions.Logging" />    
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Enrichers.Thread" />

--- a/test/xcsync.tests/Base.cs
+++ b/test/xcsync.tests/Base.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
-using System.CommandLine.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using Serilog;
@@ -103,25 +102,22 @@ public class Base : IDisposable {
 		}
 	}
 
-	public class CapturingConsole : IConsole {
+	public class CapturingConsole {
 		readonly List<string> output = [];
 		readonly List<string> error = [];
 
-		public IStandardStreamWriter Out => new ListStreamWriter (output);
-
-		public bool IsOutputRedirected => true;
-
-		public IStandardStreamWriter Error => new ListStreamWriter (error);
-
-		public bool IsErrorRedirected => true;
-
-		public bool IsInputRedirected => false;
+		public InvocationConfiguration Configuration => new () {
+			Output = new ListStreamWriter (output),
+			Error = new ListStreamWriter (error),
+		};
 
 		public IReadOnlyList<string> Output => output.AsReadOnly ();
 		public IReadOnlyList<string> ErrorOutput => error.AsReadOnly ();
 
-		class ListStreamWriter (List<string> list) : IStandardStreamWriter {
-			public void Write (string? value)
+		class ListStreamWriter (List<string> list) : TextWriter {
+			public override Encoding Encoding => Encoding.UTF8;
+
+			public override void Write (string? value)
 			{
 				if (string.IsNullOrEmpty (value))
 					return;

--- a/test/xcsync.tests/Commands/CommandValidationTests.cs
+++ b/test/xcsync.tests/Commands/CommandValidationTests.cs
@@ -35,6 +35,15 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 	}
 
 	[Fact]
+	public void BaseCommand_WhenTargetIsOmitted_UsesDefaultTarget ()
+	{
+		var command = new DefaultTargetCommand (new MockFileSystem (), new XunitLogger (TestOutput));
+		var validation = command.ValidateCommand (command.Parse ([]).CommandResult);
+
+		Assert.Equal ($"$(IntermediateOutputPath){Path.DirectorySeparatorChar}xcsync", validation.TargetPath);
+	}
+
+	[Fact]
 	public void TestXcodeCommandCreation ()
 	{
 		var fileSystem = new MockFileSystem ();
@@ -302,6 +311,13 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 
 		Assert.Equal ("The xcsync tool can only be run on macOS.", errorMessage);
 		Assert.Equal (1, exitCode);
+	}
+
+	class DefaultTargetCommand (IFileSystem fileSystem, ILogger logger) : BaseCommand<DefaultTargetCommand> (fileSystem, logger, "test", "test")
+	{
+		protected override (string, string) TryValidateProjectPath (string projectPath) => (string.Empty, projectPath);
+		protected override (string, string) TryValidateTfm (string projectPath, string tfm) => (string.Empty, tfm);
+		protected override (string, string) TryValidateTargetPath (string projectPath, string tfm, string targetPath) => (string.Empty, targetPath);
 	}
 
 	[MacOSOnlyFact]

--- a/test/xcsync.tests/Commands/CommandValidationTests.cs
+++ b/test/xcsync.tests/Commands/CommandValidationTests.cs
@@ -20,7 +20,8 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 
 		var command = new XcSyncCommand (fileSystem, Mock.Of<ILogger> ());
 		Assert.NotNull (command);
-		command.Invoke (["--dotnet-path", "/path/to/dotnet"], new CapturingConsole ());
+		var console = new CapturingConsole ();
+		command.Parse (["--dotnet-path", "/path/to/dotnet"]).Invoke (console.Configuration);
 		Assert.Equal ("/path/to/dotnet", xcSync.DotnetPath);
 	}
 
@@ -57,7 +58,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		var fileSystem = new FileSystem ();
 		var logger = new XunitLogger (TestOutput);
 		var command = new GenerateCommand (fileSystem, logger);
-		int exitCode = command.Invoke ($"--project {csproj} -f");
+		int exitCode = command.Parse ($"--project {csproj} -f").Invoke ();
 
 		// ensure the default target directory is created relative to the project directory, not the pwd
 		Assert.Equal (0, exitCode);
@@ -87,7 +88,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 			"--target", "obj/xcsync"
 		 };
 
-		int exitCode = command.Invoke (args);
+		int exitCode = command.Parse (args).Invoke ();
 
 		Assert.Equal (0, exitCode);
 	}
@@ -142,7 +143,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		 };
 
 		var console = new CapturingConsole ();
-		int exitCode = baseCommand.Invoke (args, console);
+		int exitCode = baseCommand.Parse (args).Invoke (console.Configuration);
 
 		var errorMessage = console.ErrorOutput.Count > 0 ? console.ErrorOutput [0] : string.Empty;
 
@@ -187,7 +188,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		 };
 
 		var console = new CapturingConsole ();
-		var exitCode = baseCommand.Invoke (args, console);
+		var exitCode = baseCommand.Parse (args).Invoke (console.Configuration);
 
 		var errorMessage = console.ErrorOutput.Count > 0 ? console.ErrorOutput [0] : string.Empty;
 
@@ -236,7 +237,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 			args = [.. args, "--force"];
 		}
 		var console = new CapturingConsole ();
-		int exitCode = XcodeCommand.Invoke (args, console);
+		int exitCode = XcodeCommand.Parse (args).Invoke (console.Configuration);
 
 		var errorMessage = console.ErrorOutput.Count > 0 ? console.ErrorOutput [0] : string.Empty;
 
@@ -295,7 +296,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		 };
 
 		var console = new CapturingConsole ();
-		int exitCode = baseCommand.Invoke (args, console);
+		int exitCode = baseCommand.Parse (args).Invoke (console.Configuration);
 
 		var errorMessage = console.ErrorOutput.Count > 0 ? console.ErrorOutput [0] : string.Empty;
 
@@ -332,7 +333,7 @@ public class CommandValidationTests (ITestOutputHelper TestOutput) : Base {
 		 };
 
 		var console = new CapturingConsole ();
-		int exitCode = baseCommand.Invoke (args, console);
+		int exitCode = baseCommand.Parse (args).Invoke (console.Configuration);
 
 		var errorMessage = console.ErrorOutput.Count > 0 ? console.ErrorOutput [0] : string.Empty;
 


### PR DESCRIPTION
Update the repository to .NET SDK 8.0.420 and refresh package versions within their current major versions. Migrate System.CommandLine usage to its stable API and add System.Security.Cryptography.Xml 8.0.4.


Copilot-Session: 05b77ce3-37c3-4ad9-abcc-4e36cc873561
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/xcsync/pull/256)